### PR TITLE
Feat/block details

### DIFF
--- a/scripts/build/buildDesktop.js
+++ b/scripts/build/buildDesktop.js
@@ -23,10 +23,9 @@ async function copyDistFiles(cwd) {
 
 // electron requires the base href to be relative, whereas most webservers assume a static root
 async function updateBaseHref(cwd) {
-    const indexFile = path.join(__dirname, '../../desktop/wallet/dist/index.html');
-    let indexText = await fs.readFile(indexFile, 'utf8');
+    let indexText = await fs.readFile(path.join(__dirname, '../../desktop/wallet/dist/index.html'), 'utf8');
     indexText = indexText.replace('href="/"', 'href="./"');
-    await fs.writeFile(indexFile, indexText, 'utf8');
+    await fs.writeFile(path.join(__dirname, '../../desktop/wallet/dist/index.html'), indexText, 'utf8');
 }
 
 async function build({cwd}) {

--- a/scripts/build/buildDesktop.js
+++ b/scripts/build/buildDesktop.js
@@ -21,9 +21,18 @@ async function copyDistFiles(cwd) {
     await fs.copy(src, dest);
 }
 
+// electron requires the base href to be relative, whereas most webservers assume a static root
+async function updateBaseHref(cwd) {
+    const indexFile = path.join(__dirname, '../../desktop/wallet/dist/index.html');
+    const indexText = await fs.readFile(indexFile, 'utf8');
+    indexText = indexText.replace('href="/"', 'href="./"');
+    await fs.writeFile(indexFile, indexText, 'utf8');
+}
+
 async function build({cwd}) {
     await buildAngularWallet(cwd);
     await copyDistFiles(cwd);
+    await updateBaseHref(cwd);
 }
 
 module.exports = build;

--- a/scripts/build/buildDesktop.js
+++ b/scripts/build/buildDesktop.js
@@ -24,7 +24,7 @@ async function copyDistFiles(cwd) {
 // electron requires the base href to be relative, whereas most webservers assume a static root
 async function updateBaseHref(cwd) {
     const indexFile = path.join(__dirname, '../../desktop/wallet/dist/index.html');
-    const indexText = await fs.readFile(indexFile, 'utf8');
+    let indexText = await fs.readFile(indexFile, 'utf8');
     indexText = indexText.replace('href="/"', 'href="./"');
     await fs.writeFile(indexFile, indexText, 'utf8');
 }

--- a/web/angular-wallet/src/@fuse/shared.module.ts
+++ b/web/angular-wallet/src/@fuse/shared.module.ts
@@ -7,6 +7,9 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { FuseDirectivesModule } from '@fuse/directives/directives';
 import { FusePipesModule } from '@fuse/pipes/pipes.module';
 import { TimeAgoPipe } from 'time-ago-pipe';
+import { TransactionRowValueCellComponent } from 'app/main/transactions/transaction-row-value-cell/transaction-row-value-cell.component';
+import { RouterModule } from '@angular/router';
+import { I18nModule } from 'app/layout/components/i18n/i18n.module';
 
 @NgModule({
     imports  : [
@@ -17,7 +20,9 @@ import { TimeAgoPipe } from 'time-ago-pipe';
         FlexLayoutModule,
 
         FuseDirectivesModule,
-        FusePipesModule
+        FusePipesModule,
+        I18nModule,
+        RouterModule.forChild([])
     ],
     exports  : [
         CommonModule,
@@ -28,10 +33,12 @@ import { TimeAgoPipe } from 'time-ago-pipe';
 
         FuseDirectivesModule,
         FusePipesModule,
-        TimeAgoPipe
+        TimeAgoPipe,
+        TransactionRowValueCellComponent
     ],
     declarations: [
-        TimeAgoPipe
+        TimeAgoPipe,
+        TransactionRowValueCellComponent
     ]
 })
 export class FuseSharedModule

--- a/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.html
+++ b/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.html
@@ -1,0 +1,32 @@
+<div class="page-layout blank simple" fusePerfectScrollbar>
+
+  <!-- HEADER -->
+  <div class="header accent p-24 h-160" fxLayout="column" fxLayoutAlign="center center" fxLayout.gt-xs="row"
+    fxLayoutAlign.gt-xs="space-between center">
+
+    <div fxLayout="column" fxLayoutAlign="center center" fxLayout.gt-xs="column" fxLayoutAlign.gt-xs="center start">
+      <div fxLayout="row" fxLayoutAlign="start center">
+        <mat-icon class="secondary-text s-18" [routerLink]="['/']">home</mat-icon>
+        <mat-icon class="secondary-text s-16">chevron_right</mat-icon>
+        <span class="secondary-text" [routerLink]="['/blocks']">{{ 'blocks' | i18n }}</span>
+        <mat-icon class="secondary-text s-16">chevron_right</mat-icon>
+        <span class="secondary-text">{{ block.block }}</span>
+      </div>
+      <div class="h1 mt-16">
+        <h2>{{ 'block' | i18n }}</h2>
+      </div>
+    </div>
+  </div>
+  <!-- / HEADER -->
+
+  <div class=" p-24">
+    <table class="info table">
+      <tr *ngFor="let row of getDetailsData()">
+        <th>{{ row[0] | i18n }}</th>
+        <td>
+          <app-transaction-row-value-cell [value]="row[1]" [key]="row[0]"></app-transaction-row-value-cell>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.scss
+++ b/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.scss
@@ -1,0 +1,12 @@
+
+table {
+    margin-top:10px;
+}
+
+th, td {
+    padding:5px;
+    text-align: left;
+    border-bottom:1px solid #efefef;
+    word-break: break-word;
+    min-width: 200px;
+}

--- a/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.spec.ts
+++ b/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BlockDetailsComponent } from './block-details.component';
+
+describe('BlockDetailsComponent', () => {
+  let component: BlockDetailsComponent;
+  let fixture: ComponentFixture<BlockDetailsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ BlockDetailsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BlockDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.spec.ts
+++ b/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.spec.ts
@@ -1,14 +1,72 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule, MatSortModule, MatTableModule, MatPaginatorModule  } from '@angular/material';
+import { ReactiveFormsModule } from '@angular/forms';
+import { I18nModule } from 'app/layout/components/i18n/i18n.module';
+import { BehaviorSubject } from 'rxjs';
+import { StoreService } from 'app/store/store.service';
+import { I18nService } from 'app/layout/components/i18n/i18n.service';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { BlockDetailsComponent } from './block-details.component';
+import { NetworkService } from 'app/network/network.service';
+import { TimeAgoPipe } from 'time-ago-pipe';
+import { NotifierModule } from 'angular-notifier';
+import { FuseSharedModule } from '@fuse/shared.module';
+import { TransactionRowValueCellComponent } from 'app/main/transactions/transaction-row-value-cell/transaction-row-value-cell.component';
+import { ActivatedRouteSnapshot, ActivatedRoute } from '@angular/router';
 
 describe('BlockDetailsComponent', () => {
   let component: BlockDetailsComponent;
   let fixture: ComponentFixture<BlockDetailsComponent>;
+  let activatedRoute: ActivatedRoute;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BlockDetailsComponent ]
+      imports: [
+        MatFormFieldModule,
+        MatInputModule,
+        MatSortModule,
+        MatTableModule,
+        MatIconModule,
+        MatButtonModule,
+        MatPaginatorModule,
+        HttpClientTestingModule,
+        ReactiveFormsModule, 
+        I18nModule,
+        BrowserAnimationsModule,
+        NotifierModule,
+        RouterTestingModule.withRoutes(
+          [{path: 'block/123', component: BlockDetailsComponent}]
+        )
+      ],
+      providers: [ TimeAgoPipe, I18nService, {
+        provide: StoreService,
+        useFactory: () => {
+          return {
+            ready: new BehaviorSubject(true),
+            getSettings: () => Promise.resolve({language: 'en'}),
+            saveSettings: () => Promise.resolve(true)
+          };
+        }
+      },
+      {
+        provide: NetworkService,
+        useFactory: () => {
+          return {
+            getBlockById: () => Promise.resolve({block: {block: '123'}})
+          }
+        }
+      },
+      {provide: ActivatedRoute, useValue: {
+          snapshot: {
+            data: {
+              block: '123'
+            }
+          }
+      } }],
+      declarations: [ BlockDetailsComponent, TimeAgoPipe, TransactionRowValueCellComponent ]
     })
     .compileComponents();
   }));
@@ -16,6 +74,7 @@ describe('BlockDetailsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(BlockDetailsComponent);
     component = fixture.componentInstance;
+    activatedRoute = fixture.debugElement.injector.get(ActivatedRoute);
     fixture.detectChanges();
   });
 

--- a/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.ts
+++ b/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { EncryptedMessage, Message, Account, Transaction, Block } from '@burstjs/core';
-import { StoreService } from 'app/store/store.service';
+import { EncryptedMessage, Message, Account, Block } from '@burstjs/core';
 import { ActivatedRoute } from '@angular/router';
 
 type TransactionDetailsCellValue = string | Message | EncryptedMessage | number;
@@ -13,45 +12,22 @@ type TransactionDetailsCellValueMap = [string, TransactionDetailsCellValue];
 })
 export class BlockDetailsComponent implements OnInit {
 
-  infoColumns = ['key', 'value'];
-  infoRows = ['transactionType', 'attachment', 'amountNQT', 'feeNQT', 'senderAddress', 'recipientAddress'];
-  infoData: Map<string, TransactionDetailsCellValue>;
   detailsData: Map<string, TransactionDetailsCellValue>;
   account: Account;
   block: Block
 
-  constructor(
-    private storeService: StoreService,
-    private route: ActivatedRoute) { 
+  constructor(private route: ActivatedRoute) { 
   }
-
-  getTransactionNameFromType(arg1, arg2) {
-    return `coming soon`;
-  }
-
-  closeDialog(): void {
-  }
-
-  public getInfoData(): TransactionDetailsCellValueMap[] {
-    return Array.from(this.infoData.entries());
-  } 
 
   public getDetailsData(): TransactionDetailsCellValueMap[] {
     return Array.from(this.detailsData.entries());
   } 
 
   ngOnInit() {
-    this.block = this.route.snapshot.data.transaction as Block;
-    const transactionDetails = Object.keys(this.block).map((key:string): TransactionDetailsCellValueMap => [ key, this.block[key]]);
-    this.detailsData = new Map(transactionDetails);
-    this.infoData = new Map(transactionDetails.filter((row) => this.infoRows.indexOf(row[0]) > -1));
-      
-    this.storeService.getSelectedAccount()
-      .then((account) => {
-          this.account = account;
-          // @ts-ignore
-          this.transaction.transactionType = this.getTransactionNameFromType(this.transaction, this.account);
-      });
+    console.log(this.route);
+    this.block = this.route.snapshot.data.block as Block;
+    const blockDetails = Object.keys(this.block).map((key:string): TransactionDetailsCellValueMap => [ key, this.block[key]]);
+    this.detailsData = new Map(blockDetails);
   }
 
 }

--- a/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.ts
+++ b/web/angular-wallet/src/app/main/blocks/block-details/block-details.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnInit } from '@angular/core';
+import { EncryptedMessage, Message, Account, Transaction, Block } from '@burstjs/core';
+import { StoreService } from 'app/store/store.service';
+import { ActivatedRoute } from '@angular/router';
+
+type TransactionDetailsCellValue = string | Message | EncryptedMessage | number;
+type TransactionDetailsCellValueMap = [string, TransactionDetailsCellValue];
+
+@Component({
+  selector: 'app-block-details',
+  templateUrl: './block-details.component.html',
+  styleUrls: ['./block-details.component.scss']
+})
+export class BlockDetailsComponent implements OnInit {
+
+  infoColumns = ['key', 'value'];
+  infoRows = ['transactionType', 'attachment', 'amountNQT', 'feeNQT', 'senderAddress', 'recipientAddress'];
+  infoData: Map<string, TransactionDetailsCellValue>;
+  detailsData: Map<string, TransactionDetailsCellValue>;
+  account: Account;
+  block: Block
+
+  constructor(
+    private storeService: StoreService,
+    private route: ActivatedRoute) { 
+  }
+
+  getTransactionNameFromType(arg1, arg2) {
+    return `coming soon`;
+  }
+
+  closeDialog(): void {
+  }
+
+  public getInfoData(): TransactionDetailsCellValueMap[] {
+    return Array.from(this.infoData.entries());
+  } 
+
+  public getDetailsData(): TransactionDetailsCellValueMap[] {
+    return Array.from(this.detailsData.entries());
+  } 
+
+  ngOnInit() {
+    this.block = this.route.snapshot.data.transaction as Block;
+    const transactionDetails = Object.keys(this.block).map((key:string): TransactionDetailsCellValueMap => [ key, this.block[key]]);
+    this.detailsData = new Map(transactionDetails);
+    this.infoData = new Map(transactionDetails.filter((row) => this.infoRows.indexOf(row[0]) > -1));
+      
+    this.storeService.getSelectedAccount()
+      .then((account) => {
+          this.account = account;
+          // @ts-ignore
+          this.transaction.transactionType = this.getTransactionNameFromType(this.transaction, this.account);
+      });
+  }
+
+}

--- a/web/angular-wallet/src/app/main/blocks/block-details/block.resolver.ts
+++ b/web/angular-wallet/src/app/main/blocks/block-details/block.resolver.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+import { Block } from '@burstjs/core';
+import { NetworkService } from 'app/network/network.service';
+
+@Injectable()
+export class BlockResolver implements Resolve<Promise<Block>> {
+  constructor(private networkService: NetworkService) {
+  }
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.networkService.getBlockById(route.params.id);
+  }
+}

--- a/web/angular-wallet/src/app/main/blocks/blocks.component.html
+++ b/web/angular-wallet/src/app/main/blocks/blocks.component.html
@@ -20,7 +20,7 @@
           <ng-container matColumnDef="block">
               <mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'block' | i18n }}</mat-header-cell>
               <mat-cell *matCellDef="let block">
-                  <span class="link" [routerLink]="['/block', block.block]">{{ block.block }}</span>
+                  <a [routerLink]="['block', block.block]">{{ block.block }}</a>
               </mat-cell>
           </ng-container>
 

--- a/web/angular-wallet/src/app/main/blocks/blocks.module.ts
+++ b/web/angular-wallet/src/app/main/blocks/blocks.module.ts
@@ -42,7 +42,7 @@ const routes = [
       component: BlockDetailsComponent,
       canActivate: [LoginGuard],
       resolve: {
-          transaction: BlockResolver
+          block: BlockResolver
       }
   }
 ];

--- a/web/angular-wallet/src/app/main/blocks/blocks.module.ts
+++ b/web/angular-wallet/src/app/main/blocks/blocks.module.ts
@@ -23,6 +23,10 @@ import { RouterModule } from '@angular/router';
 import { LoginGuard } from 'app/login/login-guard.service';
 import { BlocksResolver } from './blocks.resolver';
 import { BlocksComponent } from './blocks.component';
+import { BlockDetailsComponent } from './block-details/block-details.component';
+import { BlockResolver } from './block-details/block.resolver';
+import { TransactionRowValueCellComponent } from '../transactions/transaction-row-value-cell/transaction-row-value-cell.component';
+import { TransactionsModule } from '../transactions/transactions.module';
 
 const routes = [
   {
@@ -32,6 +36,14 @@ const routes = [
     resolve: {
       blocks: BlocksResolver
     }
+  },
+  {
+      path     : 'block/:id',
+      component: BlockDetailsComponent,
+      canActivate: [LoginGuard],
+      resolve: {
+          transaction: BlockResolver
+      }
   }
 ];
 
@@ -67,9 +79,11 @@ const routes = [
   ],
   declarations: [
     BlocksComponent,
+    BlockDetailsComponent
   ],
   providers: [
-    BlocksResolver
+    BlocksResolver,
+    BlockResolver
   ]
 })
 export class BlocksModule { }

--- a/web/angular-wallet/src/app/main/transactions/transaction-row-value-cell/transaction-row-value-cell.component.html
+++ b/web/angular-wallet/src/app/main/transactions/transaction-row-value-cell/transaction-row-value-cell.component.html
@@ -5,7 +5,7 @@
     <span>{{decryptedMessage}}</span>
   </span>
   <span *ngSwitchCase="'BurstAddress'">
-    <span class="link" (click)="showAccountDialog(value)">{{value}}</span>
+    <a [routerLink]="['/accounts', value]">{{value}}</a>
   </span>
   <span *ngSwitchDefault>{{value | i18n}}</span>
 </div>

--- a/web/angular-wallet/src/app/main/transactions/transaction-row-value-cell/transaction-row-value-cell.component.spec.ts
+++ b/web/angular-wallet/src/app/main/transactions/transaction-row-value-cell/transaction-row-value-cell.component.spec.ts
@@ -6,6 +6,7 @@ import { I18nModule } from 'app/layout/components/i18n/i18n.module';
 import { I18nService } from 'app/layout/components/i18n/i18n.service';
 import { StoreService } from 'app/store/store.service';
 import { BehaviorSubject } from 'rxjs';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('TransactionRowValueCellComponent', () => {
   let component: TransactionRowValueCellComponent;
@@ -15,7 +16,7 @@ describe('TransactionRowValueCellComponent', () => {
 
     TestBed.configureTestingModule({
       declarations: [ TransactionRowValueCellComponent ],
-      imports: [ I18nModule, HttpClientTestingModule ],
+      imports: [ I18nModule, HttpClientTestingModule, RouterTestingModule ],
       providers: [ I18nService, {
         provide: StoreService,
         useFactory: () => {

--- a/web/angular-wallet/src/app/main/transactions/transactions.module.ts
+++ b/web/angular-wallet/src/app/main/transactions/transactions.module.ts
@@ -19,18 +19,15 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
-import { TransactionRowValueCellComponent } from './transaction-row-value-cell/transaction-row-value-cell.component';
 import { I18nModule } from 'app/layout/components/i18n/i18n.module';
 import { FuseSharedModule } from '@fuse/shared.module';
 import { RouterModule } from '@angular/router';
 import { TransactionDetailsComponent } from './transaction-details';
 import { TransactionResolver } from './transaction.resolver';
-import { TransactionService } from './transaction.service';
 import { LoginGuard } from 'app/login/login-guard.service';
 import { TransactionsResolver } from './transactions.resolver';
 import { AccountResolver } from 'app/setup/account/account.resolver';
 import { TransactionTableModule } from './transaction-table/transaction.module';
-import { TransactionTableComponent } from './transaction-table/transaction-table.component';
 
 const routes = [
     {
@@ -80,12 +77,11 @@ const routes = [
         ReactiveFormsModule,
         I18nModule,
         MatDialogModule,
-        RouterModule.forChild(routes),
-        TransactionTableModule
+        TransactionTableModule,
+        RouterModule.forChild(routes)
     ],
     declarations: [
         TransactionsComponent,
-        TransactionRowValueCellComponent,
         TransactionDetailsComponent
     ],
     providers: [

--- a/web/angular-wallet/src/index.html
+++ b/web/angular-wallet/src/index.html
@@ -4,7 +4,7 @@
     <head>
 
         <title>BURST</title>
-        <base href="./">
+        <base href="/">
 
         <meta charset="utf-8">
         <meta name="description" content="Phoenix: Official BURST Wallet">


### PR DESCRIPTION
- Adds block details view
- Fixes the path for both electron and desktop (finally)
![image](https://user-images.githubusercontent.com/42594751/54182096-c3d9f800-445d-11e9-88a1-0d15980d67c9.png)

I want to start using [shallow](https://github.com/getsaf/shallow-render) for angular testing, it makes it wayyy easier.