### PR TITLE
implemented fetching multi-out transactions in burstjs

### DIFF
--- a/lib/packages/core/src/api/__tests__/e2e/accountApi.spec.e2e.ts
+++ b/lib/packages/core/src/api/__tests__/e2e/accountApi.spec.e2e.ts
@@ -33,7 +33,14 @@ describe(`[E2E] Account Api`, () => {
         });
 
         it('should getAccountTransactions with MultiOut', async () => {
-            const transactionList = await getAccountTransactions(service)(accountId);
+            const transactionList = await getAccountTransactions(service)(accountId,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                true
+                );
             expect(transactionList).not.toBeUndefined();
             const {transactions} = transactionList;
             expect(transactions.length).toBeGreaterThan(1);

--- a/lib/packages/core/src/api/__tests__/e2e/accountApi.spec.e2e.ts
+++ b/lib/packages/core/src/api/__tests__/e2e/accountApi.spec.e2e.ts
@@ -5,6 +5,8 @@ import {BurstService} from '../../../burstService';
 import {getAccountTransactions} from '../../factories/account/getAccountTransactions';
 import {getUnconfirmedAccountTransactions} from '../../factories/account/getUnconfirmedAccountTransactions';
 import {getAccountBalance} from '../../factories/account/getAccountBalance';
+import {TransactionType} from '../../../constants/transactionType';
+import {TransactionPaymentSubtype} from '../../../constants';
 
 const environment = loadEnvironment();
 
@@ -28,6 +30,20 @@ describe(`[E2E] Account Api`, () => {
             expect(testTransaction).toBeDefined();
             expect(testTransaction.sender).toBe(accountId);
 
+        });
+
+        it('should getAccountTransactions with MultiOut', async () => {
+            const transactionList = await getAccountTransactions(service)(accountId);
+            expect(transactionList).not.toBeUndefined();
+            const {transactions} = transactionList;
+            expect(transactions.length).toBeGreaterThan(1);
+
+            const testTransaction = transactions.filter(
+                ({type, subtype}) => type === TransactionType.Payment
+                    && (subtype === TransactionPaymentSubtype.MultiOut
+                        || subtype === TransactionPaymentSubtype.MultiOutSameAmount)
+            );
+            expect(testTransaction).toBeDefined();
         });
 
         it('should getAccountTransactions paged', async () => {

--- a/lib/packages/core/src/api/__tests__/message.spec.ts
+++ b/lib/packages/core/src/api/__tests__/message.spec.ts
@@ -3,7 +3,7 @@ import {BurstService} from '../../burstService';
 import {generateSignature} from '@burstjs/crypto';
 import {verifySignature} from '@burstjs/crypto';
 import {generateSignedTransactionBytes} from '@burstjs/crypto';
-import {constructAttachment} from '../../constructAttachment';
+import {constructAttachment} from '../../attachment/constructAttachment';
 import {sendTextMessage} from '../factories/message/sendTextMessage';
 import {broadcastTransaction} from '../factories/transaction/broadcastTransaction';
 

--- a/lib/packages/core/src/api/factories/account/getAccountTransactions.ts
+++ b/lib/packages/core/src/api/factories/account/getAccountTransactions.ts
@@ -6,7 +6,7 @@
  */
 import {BurstService} from '../../../burstService';
 import {TransactionList} from '../../../typings/transactionList';
-
+// TODO: maybe split in several getAccountTransactions like getBlocks
 export const getAccountTransactions = (service: BurstService):
     (
         accountId: string,
@@ -24,7 +24,7 @@ export const getAccountTransactions = (service: BurstService):
         numberOfConfirmations?: number,
         type?: number,
         subtype?: number,
-        includeIndirect: boolean = true
+        includeIndirect?: boolean
     ): Promise<TransactionList> =>
         service.query('getAccountTransactions', {
             account: accountId,

--- a/lib/packages/core/src/api/factories/account/getAccountTransactions.ts
+++ b/lib/packages/core/src/api/factories/account/getAccountTransactions.ts
@@ -14,7 +14,8 @@ export const getAccountTransactions = (service: BurstService):
         lastIndex?: number,
         numberOfConfirmations?: number,
         type?: number,
-        subtype?: number
+        subtype?: number,
+        includeIndirect?: boolean
     ) => Promise<TransactionList> =>
     (
         accountId: string,
@@ -22,7 +23,8 @@ export const getAccountTransactions = (service: BurstService):
         lastIndex?: number,
         numberOfConfirmations?: number,
         type?: number,
-        subtype?: number
+        subtype?: number,
+        includeIndirect: boolean = true
     ): Promise<TransactionList> =>
         service.query('getAccountTransactions', {
             account: accountId,
@@ -30,5 +32,6 @@ export const getAccountTransactions = (service: BurstService):
             lastIndex,
             numberOfConfirmations,
             type,
-            subtype
+            subtype,
+            includeIndirect
         });

--- a/lib/packages/core/src/api/factories/transaction/sendMoney.ts
+++ b/lib/packages/core/src/api/factories/transaction/sendMoney.ts
@@ -12,7 +12,7 @@ import { generateSignature, decryptAES, Keys } from '@burstjs/crypto';
 import { verifySignature } from '@burstjs/crypto';
 import { generateSignedTransactionBytes } from '@burstjs/crypto';
 import { convertNumberToNQTString, convertNQTStringToNumber } from '@burstjs/util';
-import { constructAttachment } from '../../../constructAttachment';
+import { constructAttachment } from '../../../attachment/constructAttachment';
 import {broadcastTransaction} from './broadcastTransaction';
 
 export const sendMoney = (service: BurstService):

--- a/lib/packages/core/src/attachment/__tests__/assertAttachmentVersion.spec.ts
+++ b/lib/packages/core/src/attachment/__tests__/assertAttachmentVersion.spec.ts
@@ -1,0 +1,57 @@
+import {assertAttachmentVersion} from '../assertAttachmentVersion';
+
+describe('assertAttachmentVersion', () => {
+
+    it('does not throw error in case of correct version', () => {
+        const transaction = {
+            transaction: '123',
+            attachment : { 'version.CustomVersionId' : 1, foo: 1 }
+        };
+
+        assertAttachmentVersion(transaction, 'CustomVersionId');
+        expect(true).toBeTruthy();
+
+    });
+
+    it('does throw error in case of wrong version', () => {
+        try {
+            const transaction = {
+                transaction: '123',
+                attachment : { 'version.CustomVersionId' : 1, foo: 1 }
+            };
+
+            assertAttachmentVersion(transaction, 'AnotherVersionId');
+            expect(false).toEqual('Expected exception!');
+        } catch (e) {
+            expect(e.message).toContain('Attachment of Transaction 123 is not of version \'AnotherVersionId\'');
+        }
+    });
+
+    it('does throw error in case of not existing attachment', () => {
+        try {
+            const transaction = {
+                transaction: '123'
+            };
+
+            assertAttachmentVersion(transaction, 'AnotherVersionId');
+            expect(false).toEqual('Expected exception!');
+        } catch (e) {
+            expect(e.message).toContain('Attachment of Transaction 123 is not of version \'AnotherVersionId\'');
+        }
+    });
+
+    it('does throw error in case of not existing version', () => {
+
+        try {
+            const transaction = {
+                transaction: '123',
+                attachment: {foo: 123}
+            };
+
+            assertAttachmentVersion(transaction, 'AnotherVersionId');
+            expect(false).toEqual('Expected exception!');
+        } catch (e) {
+            expect(e.message).toContain('Attachment of Transaction 123 is not of version \'AnotherVersionId\'');
+        }
+    });
+});

--- a/lib/packages/core/src/attachment/__tests__/getRecipientsFromMultiOutPayment.spec.ts
+++ b/lib/packages/core/src/attachment/__tests__/getRecipientsFromMultiOutPayment.spec.ts
@@ -1,0 +1,70 @@
+import {getRecipientsFromMultiOutPayment} from '../getRecipientsFromMultiOutPayment';
+import {TransactionType} from '../../constants/transactionType';
+import {TransactionPaymentSubtype} from '../../constants';
+
+describe('getRecipientsFromMultiOutPayment', () => {
+
+    it('returns recipients for Multi Out Same Amount Payment', () => {
+        const transaction = {
+            transaction: '123',
+            amountNQT: 'amount',
+            type: TransactionType.Payment,
+            subtype: TransactionPaymentSubtype.MultiOutSameAmount,
+            attachment: {'version.MultiOutCreation': 1, recipients: ['123', '456']}
+        };
+
+        const recipientAmounts = getRecipientsFromMultiOutPayment(transaction);
+        expect(recipientAmounts).toHaveLength(2);
+        expect(recipientAmounts[0].recipient).toBe('123');
+        expect(recipientAmounts[0].amountNQT).toBe('amount');
+        expect(recipientAmounts[1].recipient).toBe('456');
+        expect(recipientAmounts[1].amountNQT).toBe('amount');
+    });
+
+    it('returns recipients for Multi Out Different Amount Payment', () => {
+        const transaction = {
+            transaction: '123',
+            type: TransactionType.Payment,
+            subtype: TransactionPaymentSubtype.MultiOut,
+            attachment: {'version.MultiOutCreation': 1, recipients: [['123', 'amountA'], ['456', 'amountB']]}
+        };
+
+        const recipientAmounts = getRecipientsFromMultiOutPayment(transaction);
+        expect(recipientAmounts).toHaveLength(2);
+        expect(recipientAmounts[0].recipient).toBe('123');
+        expect(recipientAmounts[0].amountNQT).toBe('amountA');
+        expect(recipientAmounts[1].recipient).toBe('456');
+        expect(recipientAmounts[1].amountNQT).toBe('amountB');
+    });
+
+    it('throws exception due to wrong type', () => {
+        const transaction = {
+            transaction: '123',
+            type: TransactionType.Arbitrary,
+            attachment: {'version.MultiOutCreation': 1, recipients: [['123', 'ammountA'], ['456', 'amountB']]}
+        };
+
+        try {
+            getRecipientsFromMultiOutPayment(transaction);
+            expect(false).toBe('Expected Exception');
+        } catch (e) {
+            expect(e.message).toContain('Transaction 123 is not of type \'Multi Out Payment\'');
+        }
+    });
+
+    it('throws exception due to wrong subtype', () => {
+        const transaction = {
+            transaction: '123',
+            type: TransactionType.Payment,
+            subtype: TransactionPaymentSubtype.Ordinary,
+            attachment: {'version.MultiOutCreation': 1, recipients: [['123', 'ammountA'], ['456', 'amountB']]}
+        };
+
+        try {
+            getRecipientsFromMultiOutPayment(transaction);
+            expect(false).toBe('Expected Exception');
+        } catch (e) {
+            expect(e.message).toContain('Transaction 123 is not of type \'Multi Out Payment\'');
+        }
+    });
+});

--- a/lib/packages/core/src/attachment/assertAttachmentVersion.ts
+++ b/lib/packages/core/src/attachment/assertAttachmentVersion.ts
@@ -1,0 +1,14 @@
+import {Transaction} from '../typings/transaction';
+
+/**
+ * Asserts a specific version of a transactions attachment
+ * @param transaction The transaction to be checked
+ * @param versionIdentifier The version string, i.e. MultiOutCreation
+ * @throws An exception in case of wrong version
+ */
+export function assertAttachmentVersion(transaction: Transaction, versionIdentifier: string) {
+    const {attachment} = transaction;
+    if (attachment && attachment[`version.${versionIdentifier}`]) { return; }
+
+    throw new Error(`Attachment of Transaction ${transaction.transaction} is not of version '${versionIdentifier}'`);
+}

--- a/lib/packages/core/src/attachment/constructAttachment.ts
+++ b/lib/packages/core/src/attachment/constructAttachment.ts
@@ -1,7 +1,7 @@
 /** @module core */
 
-import { EncryptedMessage, Message } from './typings/attachment';
-import { Transaction } from './typings/transaction';
+import { EncryptedMessage, Message } from '../typings/attachment';
+import { Transaction } from '../typings/transaction';
 
 /**
  * @ignore

--- a/lib/packages/core/src/attachment/getRecipientsFromMultiOutPayment.ts
+++ b/lib/packages/core/src/attachment/getRecipientsFromMultiOutPayment.ts
@@ -1,0 +1,35 @@
+/** @module core */
+
+import {Transaction, MultioutRecipientAmount} from '..';
+import {TransactionType} from '../constants/transactionType';
+import {TransactionPaymentSubtype} from '../constants';
+import {assertAttachmentVersion} from './assertAttachmentVersion';
+
+/**
+ * Tries to extract recipients and its amounts for multi out payments (different and same amount)
+ * @param transaction The transaction
+ * @return A list of recipients and payed amount
+ * @throws An exception in case of wrong transaction types
+ */
+export function getRecipientsFromMultiOutPayment(transaction: Transaction): Array<MultioutRecipientAmount> {
+
+    assertAttachmentVersion(transaction, 'MultiOutCreation');
+
+    if (transaction.type === TransactionType.Payment
+        && transaction.subtype === TransactionPaymentSubtype.MultiOutSameAmount) {
+        return transaction.attachment.recipients.map( r => ({
+            recipient: r,
+            amountNQT: transaction.amountNQT,
+        }));
+    }
+
+    if (transaction.type === TransactionType.Payment
+        && transaction.subtype === TransactionPaymentSubtype.MultiOut) {
+        return transaction.attachment.recipients.map( r => ({
+            recipient: r[0],
+            amountNQT: r[1],
+        }) );
+    }
+
+    throw new Error(`Transaction ${transaction.transaction} is not of type 'Multi Out Payment'`);
+}

--- a/lib/packages/core/src/attachment/index.ts
+++ b/lib/packages/core/src/attachment/index.ts
@@ -1,0 +1,8 @@
+import {constructAttachment} from './constructAttachment';
+import {getRecipientsFromMultiOutPayment} from './getRecipientsFromMultiOutPayment';
+
+export {
+  constructAttachment,
+  getRecipientsFromMultiOutPayment
+};
+

--- a/lib/packages/core/src/burstService.ts
+++ b/lib/packages/core/src/burstService.ts
@@ -27,6 +27,7 @@ export class BurstService {
      * @param {string} relativePath The relative path will be prepended before each url created with toBRSEndpoint()
      * @param {Http?} httpClient If passed an client instance, it will be used instead of default HttpImpl. Good for testing.
      */
+    // TODO: introduce a Service Context class, substituting the parameter list by a single object
     constructor(baseUrl: string, relativePath: string = '', httpClient?: Http) {
         this._http = httpClient ? httpClient : new HttpImpl(baseUrl);
         this._relPath = relativePath.endsWith('/') ? relativePath.substr(0, relativePath.length - 1) : relativePath;

--- a/lib/packages/core/src/constants/index.ts
+++ b/lib/packages/core/src/constants/index.ts
@@ -1,0 +1,13 @@
+import {TransactionArbitrarySubtype} from './transactionArbitrarySubtype';
+import {TransactionAssetSubtype} from './transactionAssetSubtype';
+import {TransactionLeasingSubtype} from './transactionLeasingSubtype';
+import {TransactionMarketplaceSubtype} from './transactionMarketplaceSubtype';
+import {TransactionPaymentSubtype} from './transactionPaymentSubtype';
+
+export {
+    TransactionPaymentSubtype,
+    TransactionMarketplaceSubtype,
+    TransactionLeasingSubtype,
+    TransactionAssetSubtype,
+    TransactionArbitrarySubtype
+};

--- a/lib/packages/core/src/constants/transactionArbitrarySubtype.ts
+++ b/lib/packages/core/src/constants/transactionArbitrarySubtype.ts
@@ -1,0 +1,21 @@
+/** @module core */
+
+/**
+ * Original work Copyright (c) 2019 Burst Apps Team
+ */
+
+/**
+ * Constants for arbitrary subtypes
+ *
+ */
+export class TransactionArbitrarySubtype {
+    public static readonly Message = 0;
+    public static readonly AliasAssignment = 1;
+    public static readonly PollCreation = 2;
+    public static readonly VoteCasting = 3;
+    public static readonly HubAnnouncement = 4;
+    public static readonly AccountInfo = 5;
+    public static readonly AliasSale = 6;
+    public static readonly AliasBuy = 7;
+}
+

--- a/lib/packages/core/src/constants/transactionAssetSubtype.ts
+++ b/lib/packages/core/src/constants/transactionAssetSubtype.ts
@@ -1,0 +1,19 @@
+/** @module core */
+
+/**
+ * Original work Copyright (c) 2019 Burst Apps Team
+ */
+
+/**
+ * Constants for asset subtypes
+ *
+ */
+export class TransactionAssetSubtype {
+    public static readonly AssetIssuance = 0;
+    public static readonly AssetTransfer = 1;
+    public static readonly AskOrderPlacement = 2;
+    public static readonly BidOrderPlacement = 3;
+    public static readonly AskOrderCancellation = 4;
+    public static readonly BidOrderCancellation = 5;
+}
+

--- a/lib/packages/core/src/constants/transactionLeasingSubtype.ts
+++ b/lib/packages/core/src/constants/transactionLeasingSubtype.ts
@@ -1,0 +1,14 @@
+/** @module core */
+
+/**
+ * Original work Copyright (c) 2019 Burst Apps Team
+ */
+
+/**
+ * Constants for leasing subtypes
+ *
+ */
+export class TransactionLeasingSubtype {
+    public static readonly Ordinary = 0;
+}
+

--- a/lib/packages/core/src/constants/transactionMarketplaceSubtype.ts
+++ b/lib/packages/core/src/constants/transactionMarketplaceSubtype.ts
@@ -1,0 +1,21 @@
+/** @module core */
+
+/**
+ * Original work Copyright (c) 2019 Burst Apps Team
+ */
+
+/**
+ * Constants for marketplace subtypes
+ *
+ */
+export class TransactionMarketplaceSubtype {
+    public static readonly MarketplaceListing = 0;
+    public static readonly MarketplaceRemoval = 1;
+    public static readonly MarketplaceItemPriceChange = 2;
+    public static readonly MarketplaceItemQuantityChange = 3;
+    public static readonly MarketplacePurchase = 4;
+    public static readonly MarketplaceDelivery = 5;
+    public static readonly MarketplaceFeedback = 6;
+    public static readonly MarketplaceRefund = 7;
+}
+

--- a/lib/packages/core/src/constants/transactionPaymentSubtype.ts
+++ b/lib/packages/core/src/constants/transactionPaymentSubtype.ts
@@ -1,0 +1,16 @@
+/** @module core */
+
+/**
+ * Original work Copyright (c) 2019 Burst Apps Team
+ */
+
+/**
+ * Constants for payment subtypes
+ *
+ */
+export class TransactionPaymentSubtype {
+    public static readonly Ordinary = 0;
+    public static readonly MultiOut = 1;
+    public static readonly MultiOutSameAmount = 2;
+}
+

--- a/lib/packages/core/src/constants/transactionType.ts
+++ b/lib/packages/core/src/constants/transactionType.ts
@@ -1,0 +1,36 @@
+/** @module core */
+
+/**
+ * Original work Copyright (c) 2019 Burst Apps Team
+ */
+
+/**
+ * Constants for transaction types
+ *
+ * The transaction type is part of every [[Transaction]] object
+ * and used to distinguish block data. Additionally, to the transaction type
+ * a subtype is sent, that specifies the kind of transaction more detailly.
+ */
+export class TransactionType {
+    /**
+     * @see TransactionPaymentSubtype
+     */
+    public static readonly Payment = 0;
+    /**
+     * @see TransactionArbitrarySubtype
+     */
+    public static readonly Arbitrary = 1;
+    /**
+     * @see TransactionAssetSubtype
+     */
+    public static readonly Asset = 2;
+    /**
+     * @see TransactionMarketplaceSubtype
+     */
+    public static readonly Marketplace = 3;
+    /**
+     * @see TransactionLeasingSubtype
+     */
+    public static readonly Leasing = 4;
+}
+

--- a/lib/packages/core/src/index.ts
+++ b/lib/packages/core/src/index.ts
@@ -18,7 +18,10 @@ export * from './typings/transactionId';
 export * from './typings/transactionList';
 export * from './typings/transactionResponse';
 export * from './typings/unconfirmedTransactionList';
+export * from './typings/multioutRecipientAmount';
 export * from './typings/burstTime';
 export * from './api';
+export * from './attachment';
+export * from './constants';
 
 

--- a/lib/packages/core/src/typings/api/accountApi.ts
+++ b/lib/packages/core/src/typings/api/accountApi.ts
@@ -20,6 +20,7 @@ export interface AccountApi {
      * @param {number?} numberOfConfirmations The minimum required number of confirmations per transaction
      * @param {number?} type The type of transactions to fetch
      * @param {number?} subtype The subtype of transactions to fetch
+     * @param {boolean?} includeIndirect Includes indirect transaction, i.e. multi out payments. Default is `true`
      * @return {Promise<TransactionList>} List of transactions
      */
     getAccountTransactions: (
@@ -28,7 +29,8 @@ export interface AccountApi {
         lastIndex?: number,
         numberOfConfirmations?: number,
         type?: number,
-        subtype?: number
+        subtype?: number,
+        includeIndirect?: boolean
     ) => Promise<TransactionList>;
 
 

--- a/lib/packages/core/src/typings/attachment.ts
+++ b/lib/packages/core/src/typings/attachment.ts
@@ -11,6 +11,8 @@
 * The attachment class is used to appended to transaction where appropriate.
 * It is a super class for Message and EncryptedMessage.
 */
+
+// TODO: review attachment, as this applies only for sending messages
 export class Attachment {
     public type?: string;
 

--- a/lib/packages/core/src/typings/multioutRecipientAmount.ts
+++ b/lib/packages/core/src/typings/multioutRecipientAmount.ts
@@ -1,0 +1,4 @@
+export interface MultioutRecipientAmount {
+    readonly recipient: string;
+    readonly amountNQT: string;
+}

--- a/lib/packages/core/src/typings/transaction.ts
+++ b/lib/packages/core/src/typings/transaction.ts
@@ -30,3 +30,4 @@ export interface Transaction {
     readonly recipient?: string;
     readonly recipientRS?: string;
 }
+


### PR DESCRIPTION
New feature: MultiOut transaction fetching supported

Note, that this is not applied to the wallet yet. Btw: the proxy points to a BRS 2.3.0 test node....need at least BRS 2.3.1. to not break, when using multi-out feature