### PR TITLE
Fix/account issues

### DIFF
--- a/web/angular-wallet/src/app/setup/account/account.service.ts
+++ b/web/angular-wallet/src/app/setup/account/account.service.ts
@@ -212,7 +212,7 @@ export class AccountService {
         account.balanceNQT = remoteAccount.balanceNQT;
         account.unconfirmedBalanceNQT = remoteAccount.unconfirmedBalanceNQT;
 
-        const transactionList = await this.getAccountTransactions(account.account);
+        const transactionList = await this.getAccountTransactions(account.account, 0, 500);
         account.transactions = transactionList.transactions;
 
         const unconfirmedTransactionsResponse = await this.getUnconfirmedTransactions(account.account);

--- a/web/angular-wallet/src/app/setup/account/account.service.ts
+++ b/web/angular-wallet/src/app/setup/account/account.service.ts
@@ -202,29 +202,49 @@ export class AccountService {
   */
   public synchronizeAccount(account: Account): Promise<Account> {
     return new Promise(async (resolve, reject) => {
-      try {
-
-        const remoteAccount = await this.getAccount(account.account);
-        account.name = remoteAccount.name;
-        account.description = remoteAccount.description;
-        account.assetBalances = remoteAccount.assetBalances;
-        account.unconfirmedAssetBalances = remoteAccount.unconfirmedAssetBalances;
-        account.balanceNQT = remoteAccount.balanceNQT;
-        account.unconfirmedBalanceNQT = remoteAccount.unconfirmedBalanceNQT;
-
-        const transactionList = await this.getAccountTransactions(account.account, 0, 500);
-        account.transactions = transactionList.transactions;
-
-        const unconfirmedTransactionsResponse = await this.getUnconfirmedTransactions(account.account);
-        account.transactions = unconfirmedTransactionsResponse.unconfirmedTransactions
-          .concat(account.transactions);
-
-      } catch (e) {
-        console.log(e);
-      }
+      // todo: parallelize
+      await this.syncAccountDetails(account);
+      await this.syncAccountTransactions(account);
+      await this.syncAccountUnconfirmedTransactions(account);
 
       this.storeService.saveAccount(account).catch(error => { reject(error); });
       resolve(account);
     });
+  }
+
+  private async syncAccountUnconfirmedTransactions(account: Account): Promise<void> {
+    try {
+      const unconfirmedTransactionsResponse = await this.getUnconfirmedTransactions(account.account);
+      account.transactions = unconfirmedTransactionsResponse.unconfirmedTransactions
+        .concat(account.transactions);
+    }
+    catch (e) {
+      console.log(e);
+    }
+  }
+
+  private async syncAccountTransactions(account: Account): Promise<void> {
+    try {
+      const transactionList = await this.getAccountTransactions(account.account, 0, 500);
+      account.transactions = transactionList.transactions;
+    }
+    catch (e) {
+      console.log(e);
+    }
+  }
+
+  private async syncAccountDetails(account: Account): Promise<void> {
+    try {
+      const remoteAccount = await this.getAccount(account.account);
+      account.name = remoteAccount.name;
+      account.description = remoteAccount.description;
+      account.assetBalances = remoteAccount.assetBalances;
+      account.unconfirmedAssetBalances = remoteAccount.unconfirmedAssetBalances;
+      account.balanceNQT = remoteAccount.balanceNQT;
+      account.unconfirmedBalanceNQT = remoteAccount.unconfirmedBalanceNQT;
+    }
+    catch (e) {
+      console.log(e);
+    }
   }
 }

--- a/web/angular-wallet/src/app/setup/account/create-active/pin/pin.component.ts
+++ b/web/angular-wallet/src/app/setup/account/create-active/pin/pin.component.ts
@@ -35,6 +35,10 @@ export class AccountCreatePinComponent implements OnInit {
         this.createService.createActiveAccount().then((success) => {
             this.notificationService.notify('success', `Account added successfully`);
             this.createService.reset();
+            // Angular Stepper hack
+            setTimeout(x => {
+                this.createService.setStepIndex(0);
+            }, 0);
             this.router.navigate(['/']);
           },
           (error) => {

--- a/web/angular-wallet/src/app/setup/account/create.service.ts
+++ b/web/angular-wallet/src/app/setup/account/create.service.ts
@@ -77,7 +77,6 @@ export class CreateService {
     }
 
     public reset() {
-        this.setStepIndex(0);
         this.passphrase = [];
         this.account = undefined;
         this.accountRS = undefined;


### PR DESCRIPTION
Closes #246, #248, #250.

- Restricts transactions to 500 on first account sync. Transactions page still shows the full list. (#248)
- Gets transactions and unconfirmed transactions even if the getAccount call fails. (#246)
- Resets the stepper properly. (#250)