### PR TITLE
introduced convenience class for unsubscribe

### DIFF
--- a/web/angular-wallet/src/app/util/UnsubscribeOnDestroy.ts
+++ b/web/angular-wallet/src/app/util/UnsubscribeOnDestroy.ts
@@ -1,0 +1,15 @@
+import {OnDestroy} from '@angular/core';
+import {Subject} from 'rxjs';
+
+export class UnsubscribeOnDestroy implements OnDestroy {
+  private _unsubscribeAll = new Subject();
+
+  get unsubscribeAll(): Subject<any> {
+    return this._unsubscribeAll;
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribeAll.next();
+    this._unsubscribeAll.complete();
+  }
+}


### PR DESCRIPTION
now you can do this:

```ts
class MyComponent extends UnsubscribeOnDestroy implements OnInit, AfterViewInit {
 // ...

 public ngOnInit(): void {
    this.storeService.ready
      .pipe(
        takeUntil(this.unsubscribeAll)
      )
      .subscribe((ready) => {
         // ....
      });
  }
```

No need to care for unsubscription in `ngDestroy`