### PR TITLE
Feature/alias recipient send burst

### DIFF
--- a/lib/packages/core/CHANGELOG.md
+++ b/lib/packages/core/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 - added `confirmed` property to `Account` model
+- added `alias` api
 
 ## 0.1.1
 - added FeeQuant for `suggestFees`

--- a/lib/packages/core/src/api/apiComposer.ts
+++ b/lib/packages/core/src/api/apiComposer.ts
@@ -5,6 +5,7 @@
  */
 
 import {Api} from '../typings/api';
+import {AliasApi} from '../typings/api/aliasApi';
 import {BlockApi} from '../typings/api/blockApi';
 import {AccountApi} from '../typings/api/accountApi';
 import {MessageApi} from '../typings/api/messageApi';
@@ -14,6 +15,7 @@ import {BurstService} from '../service/burstService';
 
 
 class ApiImpl implements Api {
+    alias: AliasApi;
     account: AccountApi;
     block: BlockApi;
     message: MessageApi;
@@ -119,6 +121,15 @@ export class ApiComposer {
      */
     public withTransactionApi(creatorMap: any): ApiComposer {
         this.mapCreators('transaction', creatorMap);
+        return this;
+    }
+
+    /**
+     * Adds the [[AliasApi]]  to be composed
+     * @param creatorMap A map of creator/factory functions for the endpoints
+     */
+    public withAliasApi(creatorMap: any): ApiComposer {
+        this.mapCreators('alias', creatorMap);
         return this;
     }
 

--- a/lib/packages/core/src/api/composeApi.ts
+++ b/lib/packages/core/src/api/composeApi.ts
@@ -38,6 +38,8 @@ import {getAccount} from './factories/account/getAccount';
 import {setAccountInfo} from './factories/account/setAccountInfo';
 import {BurstServiceSettings} from '../service/burstServiceSettings';
 import {ApiVersion} from '../constants/apiVersion';
+import {getAliasById} from './factories/alias/getAliasById';
+import {getAliasByName} from './factories/alias/getAliasByName';
 
 
 /**
@@ -111,6 +113,10 @@ export function composeApi(settings: ApiSettings): Api {
             setAlias,
             getAccount,
             setAccountInfo,
+        }).withAliasApi({
+            getAliasByName,
+            getAliasById,
+            setAlias
         })
         .compose();
 

--- a/lib/packages/core/src/api/factories/alias/getAliasById.ts
+++ b/lib/packages/core/src/api/factories/alias/getAliasById.ts
@@ -1,0 +1,18 @@
+/** @module core.api.factories */
+
+/**
+ * Copyright (c) 2019 Burst Apps Team
+ */
+import {BurstService} from '../../../service/burstService';
+import {AliasList} from '../../../typings/aliasList';
+
+/**
+ * Use with [[ApiComposer]] and belongs to [[AliasApi]].
+ *
+ * See details at [[AliasApi.getAliasById]]
+ */
+export const getAliasById = (service: BurstService):
+    (aliasId: string) => Promise<AliasList> =>
+    (aliasId: string): Promise<AliasList> => service.query('getAlias', {
+        aliasId,
+    });

--- a/lib/packages/core/src/api/factories/alias/getAliasByName.ts
+++ b/lib/packages/core/src/api/factories/alias/getAliasByName.ts
@@ -1,0 +1,18 @@
+/** @module core.api.factories */
+
+/**
+ * Copyright (c) 2019 Burst Apps Team
+ */
+import {BurstService} from '../../../service/burstService';
+import {AliasList} from '../../../typings/aliasList';
+
+/**
+ * Use with [[ApiComposer]] and belongs to [[AliasApi]].
+ *
+ * See details at [[AliasApi.getAliasByName]]
+ */
+export const getAliasByName = (service: BurstService):
+    (aliasName: string) => Promise<AliasList> =>
+    (aliasName: string): Promise<AliasList> => service.query('getAlias', {
+        aliasName
+    });

--- a/lib/packages/core/src/api/factories/alias/index.ts
+++ b/lib/packages/core/src/api/factories/alias/index.ts
@@ -1,0 +1,6 @@
+/** @module core.api.factories */
+
+export * from './getAliasById';
+export * from './getAliasByName';
+// TODO: move setAlias from account api to alias api
+// export * from './setAlias';

--- a/lib/packages/core/src/api/factories/alias/setAlias.ts
+++ b/lib/packages/core/src/api/factories/alias/setAlias.ts
@@ -1,0 +1,53 @@
+/** @module core.api.factories */
+
+/**
+ * Copyright (c) 2019 Burst Apps Team
+ */
+import {BurstService} from '../../../service/burstService';
+import {TransactionId} from '../../../typings/transactionId';
+import {TransactionResponse} from '../../../typings/transactionResponse';
+import {generateSignature} from '@burstjs/crypto';
+import {verifySignature} from '@burstjs/crypto';
+import {generateSignedTransactionBytes} from '@burstjs/crypto';
+import {convertNumberToNQTString} from '@burstjs/util';
+import {broadcastTransaction} from '../transaction/broadcastTransaction';
+
+/**
+ * Use with [[ApiComposer]] and belongs to [[AliasApi]].
+ *
+ * See details at [[AliasApi.setAlias]]
+ */
+export const setAlias = (service: BurstService): (
+    aliasName: string,
+    aliasURI: string,
+    feeNQT: string,
+    senderPublicKey: string,
+    senderPrivateKey: string,
+    deadline: number,
+) => Promise<TransactionId> =>
+    async (
+        aliasName: string,
+        aliasURI: string,
+        feeNQT: string,
+        senderPublicKey: string,
+        senderPrivateKey: string,
+        deadline: number,
+    ): Promise<TransactionId> => {
+
+        const parameters = {
+            aliasName,
+            aliasURI,
+            deadline: deadline,
+            feeNQT: convertNumberToNQTString(parseFloat(feeNQT)),
+            publicKey: senderPublicKey
+        };
+        const {unsignedTransactionBytes} = await service.send<TransactionResponse>('setAlias', parameters);
+        const signature = generateSignature(unsignedTransactionBytes, senderPrivateKey);
+        if (!verifySignature(signature, unsignedTransactionBytes, senderPublicKey)) {
+            throw new Error('The signed message could not be verified! Transaction not broadcasted!');
+        }
+
+        const signedMessage = generateSignedTransactionBytes(unsignedTransactionBytes, signature);
+        return broadcastTransaction(service)(signedMessage);
+
+    };

--- a/lib/packages/core/src/api/factories/index.ts
+++ b/lib/packages/core/src/api/factories/index.ts
@@ -1,6 +1,7 @@
 /** @module core.api.factories */
 
 export * from './account';
+export * from './alias';
 export * from './block';
 export * from './network';
 export * from './message';

--- a/lib/packages/core/src/typings/api/aliasApi.ts
+++ b/lib/packages/core/src/typings/api/aliasApi.ts
@@ -1,0 +1,57 @@
+/** @module core.api */
+
+import {TransactionId} from '../transactionId';
+import {Alias} from '../alias';
+
+/**
+ * Alias API
+ *
+ * Work in Progress
+ */
+export interface AliasApi {
+
+    /**
+     * Get alias by its id, i.e. get basic account info for given alias name
+     * @param {string} aliasId The alias id
+     * @return {Promise<Alias>} List of transactions
+     */
+    getAliasById: (
+        aliasId: string,
+    ) => Promise<Alias>;
+
+
+    /**
+     * Get alias by name, i.e. get basic account info for given alias name
+     * @param {string} aliasName The alias name
+     * @return {Promise<Alias>} List of transactions
+     */
+    getAliasByName: (
+        aliasName: string,
+    ) => Promise<Alias>;
+
+    /**
+     * Registers an Alias with the Burst blockchain
+     *
+     * The transaction will be broadcasted in two steps.
+     * 1. Send the setAlias call with public key to the network
+     * 2. Take the returned unsigned message and sign it, i.e. the private key won't be transmitted.
+     *
+     * @param aliasName The alias name
+     * @param aliasURI The alias URI
+     * @param feeNQT The fee to pay
+     * @param name The name of the account
+     * @param senderPublicKey The senders public key for sending an _unsigned_ message
+     * @param senderPrivateKey The senders private key to _sign_ the message
+     * @param deadline The deadline, in minutes, for the transaction to be confirmed
+     * @return The Transaction ID
+     */
+    setAlias: (
+        aliasName: string,
+        aliasURI: string,
+        feeNQT: string,
+        senderPublicKey: string,
+        senderPrivateKey: string,
+        deadline?: number,
+    ) => Promise<TransactionId>;
+
+}

--- a/lib/packages/core/src/typings/api/index.ts
+++ b/lib/packages/core/src/typings/api/index.ts
@@ -5,6 +5,7 @@ import {NetworkApi} from './networkApi';
 import {TransactionApi} from './transactionApi';
 import {MessageApi} from './messageApi';
 import {AccountApi} from './accountApi';
+import {AliasApi} from './aliasApi';
 
 
 export {
@@ -13,6 +14,7 @@ export {
     TransactionApi,
     MessageApi,
     AccountApi,
+    AliasApi
 };
 
 /**
@@ -41,4 +43,5 @@ export class Api {
     readonly transaction: TransactionApi;
     readonly message: MessageApi;
     readonly account: AccountApi;
+    readonly alias: AliasApi;
 }

--- a/web/angular-wallet/src/app/layout/components/burst-recipient-input/burst-recipient-input.component.html
+++ b/web/angular-wallet/src/app/layout/components/burst-recipient-input/burst-recipient-input.component.html
@@ -1,0 +1,22 @@
+<mat-form-field>
+  <div fxFlex="1 0 auto" fxLayout="row" fxLayoutAlign="start center">
+    <input matInput
+           [(ngModel)]="recipient"
+           (ngModelChange)="applyRecipientType($event)"
+           (blur)="validateRecipient()"
+           name="recipient"
+           placeholder="{{ 'recipient' | i18n }}">
+
+    <div *ngIf="recipientType!==1" class="recipient-address">{{recipientRS}}</div>
+    <div fxFlex fxLayout="row"
+         *ngIf="recipientType>0"
+         [ngClass]="getValidationClass()"
+         matTooltip="{{getValidationHint()}}"
+    >
+      <div>{{getRecipientTypeName()}}</div>
+      <mat-icon [ngClass]="recipientTypeValidationStatus === 'valid' ? '' : 'fuse-black-500-fg'">
+        {{getValidationIcon()}}
+      </mat-icon>
+    </div>
+  </div>
+</mat-form-field>

--- a/web/angular-wallet/src/app/layout/components/burst-recipient-input/burst-recipient-input.component.scss
+++ b/web/angular-wallet/src/app/layout/components/burst-recipient-input/burst-recipient-input.component.scss
@@ -1,0 +1,45 @@
+mat-form-field {
+  width: 100%;
+
+  .badge {
+    font-size: 12px;
+    border-radius: 4px;
+    padding: 2px 8px;
+    align-items: center;
+    justify-content: center;
+
+    &.invalid {
+      background: darkorange;
+    }
+
+    &.valid {
+      color: white;
+      background: #00b386;
+    }
+
+    &.unknown {
+      background: lightgray;
+    }
+
+    mat-icon {
+      margin: 0;
+      padding: 0 0 0 4px;
+      min-height: 8px;
+      min-width: 8px;
+      width: 16px;
+      height: 16px;
+      font-size: 16px;
+    }
+  }
+
+  .recipient-address {
+    position: relative;
+    color: darkgray;
+    font-size: 10px;
+    margin: 0;
+    width: 50%
+  }
+}
+
+
+

--- a/web/angular-wallet/src/app/layout/components/burst-recipient-input/burst-recipient-input.component.spec.ts
+++ b/web/angular-wallet/src/app/layout/components/burst-recipient-input/burst-recipient-input.component.spec.ts
@@ -1,0 +1,81 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BurstRecipientInputComponent } from './recipient-input.component';
+import {Ng5SliderModule} from 'ng5-slider';
+import {MatIconModule, MatTooltipModule} from '@angular/material';
+import {I18nModule} from '../i18n/i18n.module';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {BurstFeeSelectorComponent} from '../burst-fee-selector/burst-fee-selector.component';
+import {I18nService} from '../i18n/i18n.service';
+import {StoreService} from '../../../store/store.service';
+import {BehaviorSubject} from 'rxjs';
+import {TransactionService} from '../../../main/transactions/transaction.service';
+import {AccountService} from '../../../setup/account/account.service';
+import {BurstInputValidatorDirective} from '../../../main/send-burst/send-burst-validator.directive';
+import {FeeQuantNQT} from '@burstjs/core';
+
+describe('RecipientInputComponent', () => {
+  let component: BurstRecipientInputComponent;
+  let fixture: ComponentFixture<BurstRecipientInputComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        Ng5SliderModule,
+        MatTooltipModule,
+        MatIconModule,
+        I18nModule,
+        HttpClientTestingModule
+      ],
+      declarations: [ BurstFeeSelectorComponent ],
+      providers: [
+        I18nService,
+        {
+          provide: StoreService,
+          useFactory: () => {
+            return {
+              ready: new BehaviorSubject(true),
+              getSettings: () => Promise.resolve({language: 'en'}),
+              saveSettings: () => Promise.resolve(true)
+            };
+          }
+        },
+        {
+          provide: TransactionService,
+          useFactory: () => {
+            return {
+              sendMoney: () => Promise.resolve({broadcasted: true})
+            };
+          }
+        },
+        {
+          provide: AccountService,
+          useFactory: () => {
+            return {
+              currentAccount: new BehaviorSubject(true)
+            };
+          }
+        },
+        BurstInputValidatorDirective
+      ]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BurstFeeSelectorComponent);
+    component = fixture.componentInstance;
+    component.fees = {
+      minimum: FeeQuantNQT,
+      cheap: 0.1,
+      standard: 0.2,
+      priority: 0.3,
+      requestProcessingTime: 0.1
+    };
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web/angular-wallet/src/app/layout/components/burst-recipient-input/burst-recipient-input.component.ts
+++ b/web/angular-wallet/src/app/layout/components/burst-recipient-input/burst-recipient-input.component.ts
@@ -1,0 +1,120 @@
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {convertAddressToNumericId} from '@burstjs/util';
+import {AccountService} from '../../../setup/account/account.service';
+
+enum RecipientType {
+  UNKNOWN = 0,
+  ADDRESS = 1,
+  ID,
+  ALIAS,
+}
+
+enum ValidationStatus {
+  UNKNOWN = 'unknown',
+  INVALID = 'invalid',
+  VALID = 'valid',
+}
+
+
+@Component({
+  selector: 'burst-recipient-input',
+  templateUrl: './burst-recipient-input.component.html',
+  styleUrls: ['./burst-recipient-input.component.scss']
+})
+export class BurstRecipientInputComponent implements OnInit {
+  recipientTypeValidationStatus = ValidationStatus.UNKNOWN;
+  recipientType = RecipientType.UNKNOWN;
+  recipientValue = '';
+  recipientRS = '';
+
+  @Output()
+  recipientChange = new EventEmitter();
+
+  set recipient(r: string) {
+    this.recipientValue = r;
+  }
+
+  constructor(private accountService: AccountService) { }
+
+  ngOnInit(): void {
+  }
+
+  applyRecipientType(recipient: string): void {
+    this.recipientRS = '';
+    this.recipientTypeValidationStatus = ValidationStatus.UNKNOWN;
+    const r = recipient.trim();
+    if (r.length === 0) {
+      this.recipientType = RecipientType.UNKNOWN;
+    } else if (r.startsWith('BURST-')) {
+      this.recipientType = RecipientType.ADDRESS;
+    } else if (/^\d+$/.test(r)) {
+      this.recipientType = RecipientType.ID;
+    } else {
+      this.recipientType = RecipientType.ALIAS;
+    }
+  }
+
+
+  validateRecipient(): void {
+    let accountFetchFn;
+    let id = this.recipientValue.trim();
+    switch (this.recipientType) {
+      case RecipientType.ALIAS:
+        accountFetchFn = this.accountService.getAlias;
+        break;
+      case RecipientType.ADDRESS:
+        id = convertAddressToNumericId(id);
+      // tslint:disable-next-line:no-switch-case-fall-through
+      case RecipientType.ID:
+        accountFetchFn = this.accountService.getAccount;
+        break;
+      default:
+      // no op
+    }
+
+    if (!accountFetchFn) {
+      return;
+    }
+
+    accountFetchFn.call(this.accountService, id).then( ({accountRS}) => {
+      this.recipientRS = accountRS;
+      this.recipientTypeValidationStatus = ValidationStatus.VALID;
+      this.recipientChange.emit(this.recipientRS);
+    }).catch(() => {
+      this.recipientRS = '';
+      this.recipientTypeValidationStatus = ValidationStatus.INVALID;
+      this.recipientChange.emit(this.recipientRS);
+    });
+
+
+  }
+
+  getRecipientTypeName = (): string => RecipientType[this.recipientType];
+
+  getValidationHint(): string {
+    // TODO: localization
+    switch (this.recipientTypeValidationStatus){
+      case ValidationStatus.UNKNOWN:
+        return 'The address was not validated yet';
+      case ValidationStatus.VALID:
+        return 'Address was successfully verified';
+      case ValidationStatus.INVALID:
+        return 'This address does not seem valid. Verify if it really exists!';
+    }
+  }
+
+  getValidationIcon(): string {
+    switch (this.recipientTypeValidationStatus){
+      case ValidationStatus.UNKNOWN:
+        return 'help_outline';
+      case ValidationStatus.VALID:
+        return 'check_circle';
+      case ValidationStatus.INVALID:
+        return 'error_outline';
+    }
+  }
+
+  getValidationClass(): string {
+    return 'badge ' + this.recipientTypeValidationStatus.toString().toLocaleLowerCase();
+  }
+}

--- a/web/angular-wallet/src/app/layout/layout.module.ts
+++ b/web/angular-wallet/src/app/layout/layout.module.ts
@@ -1,18 +1,17 @@
-import { NgModule } from '@angular/core';
+import {NgModule} from '@angular/core';
 
-import { VerticalLayout1Module } from 'app/layout/vertical/layout-1/layout-1.module';
-import { VerticalLayout2Module } from 'app/layout/vertical/layout-2/layout-2.module';
-import { VerticalLayout3Module } from 'app/layout/vertical/layout-3/layout-3.module';
+import {VerticalLayout1Module} from 'app/layout/vertical/layout-1/layout-1.module';
+import {VerticalLayout2Module} from 'app/layout/vertical/layout-2/layout-2.module';
+import {VerticalLayout3Module} from 'app/layout/vertical/layout-3/layout-3.module';
 
-import { HorizontalLayout1Module } from 'app/layout/horizontal/layout-1/layout-1.module';
-import { BurstFeeSelectorComponent } from './components/burst-fee-selector/burst-fee-selector.component';
-import { Ng5SliderModule } from 'ng5-slider';
+import {HorizontalLayout1Module} from 'app/layout/horizontal/layout-1/layout-1.module';
+import {Ng5SliderModule} from 'ng5-slider';
 import {MatFormFieldModule, MatIconModule, MatInputModule, MatTooltipModule} from '@angular/material';
 import {I18nModule} from './components/i18n/i18n.module';
 import {FormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
-import {FlexModule} from '@angular/flex-layout';
 import {BurstRecipientInputComponent} from './components/burst-recipient-input/burst-recipient-input.component';
+import {BurstFeeSelectorComponent} from './components/burst-fee-selector/burst-fee-selector.component';
 
 @NgModule({
   imports: [
@@ -28,20 +27,18 @@ import {BurstRecipientInputComponent} from './components/burst-recipient-input/b
     FormsModule,
     MatFormFieldModule,
     CommonModule,
-    FlexModule,
     MatInputModule
   ],
-    exports: [
-        VerticalLayout1Module,
-        VerticalLayout2Module,
-        VerticalLayout3Module,
+  exports: [
+    VerticalLayout1Module,
+    VerticalLayout2Module,
+    VerticalLayout3Module,
 
-        HorizontalLayout1Module,
-        BurstFeeSelectorComponent,
-        BurstRecipientInputComponent
-    ],
-    declarations: [BurstFeeSelectorComponent, BurstRecipientInputComponent]
+    HorizontalLayout1Module,
+    BurstFeeSelectorComponent,
+    BurstRecipientInputComponent
+  ],
+  declarations: [BurstFeeSelectorComponent, BurstRecipientInputComponent]
 })
-export class LayoutModule
-{
+export class LayoutModule {
 }

--- a/web/angular-wallet/src/app/layout/layout.module.ts
+++ b/web/angular-wallet/src/app/layout/layout.module.ts
@@ -12,7 +12,7 @@ import {FormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
 import {BurstRecipientInputComponent} from './components/burst-recipient-input/burst-recipient-input.component';
 import {BurstFeeSelectorComponent} from './components/burst-fee-selector/burst-fee-selector.component';
-import {FlexModule} from '@angular/flex-layout';
+import {FlexLayoutModule} from '@angular/flex-layout';
 
 @NgModule({
   imports: [
@@ -29,7 +29,7 @@ import {FlexModule} from '@angular/flex-layout';
     MatFormFieldModule,
     CommonModule,
     MatInputModule,
-    FlexModule
+    FlexLayoutModule
   ],
   exports: [
     VerticalLayout1Module,

--- a/web/angular-wallet/src/app/layout/layout.module.ts
+++ b/web/angular-wallet/src/app/layout/layout.module.ts
@@ -7,8 +7,12 @@ import { VerticalLayout3Module } from 'app/layout/vertical/layout-3/layout-3.mod
 import { HorizontalLayout1Module } from 'app/layout/horizontal/layout-1/layout-1.module';
 import { BurstFeeSelectorComponent } from './components/burst-fee-selector/burst-fee-selector.component';
 import { Ng5SliderModule } from 'ng5-slider';
-import {MatIconModule, MatTooltipModule} from '@angular/material';
+import {MatFormFieldModule, MatIconModule, MatInputModule, MatTooltipModule} from '@angular/material';
 import {I18nModule} from './components/i18n/i18n.module';
+import {FormsModule} from '@angular/forms';
+import {CommonModule} from '@angular/common';
+import {FlexModule} from '@angular/flex-layout';
+import {BurstRecipientInputComponent} from './components/burst-recipient-input/burst-recipient-input.component';
 
 @NgModule({
   imports: [
@@ -20,7 +24,12 @@ import {I18nModule} from './components/i18n/i18n.module';
     Ng5SliderModule,
     MatTooltipModule,
     MatIconModule,
-    I18nModule
+    I18nModule,
+    FormsModule,
+    MatFormFieldModule,
+    CommonModule,
+    FlexModule,
+    MatInputModule
   ],
     exports: [
         VerticalLayout1Module,
@@ -28,9 +37,10 @@ import {I18nModule} from './components/i18n/i18n.module';
         VerticalLayout3Module,
 
         HorizontalLayout1Module,
-        BurstFeeSelectorComponent
+        BurstFeeSelectorComponent,
+        BurstRecipientInputComponent
     ],
-    declarations: [BurstFeeSelectorComponent]
+    declarations: [BurstFeeSelectorComponent, BurstRecipientInputComponent]
 })
 export class LayoutModule
 {

--- a/web/angular-wallet/src/app/layout/layout.module.ts
+++ b/web/angular-wallet/src/app/layout/layout.module.ts
@@ -12,6 +12,7 @@ import {FormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
 import {BurstRecipientInputComponent} from './components/burst-recipient-input/burst-recipient-input.component';
 import {BurstFeeSelectorComponent} from './components/burst-fee-selector/burst-fee-selector.component';
+import {FlexModule} from '@angular/flex-layout';
 
 @NgModule({
   imports: [
@@ -27,7 +28,8 @@ import {BurstFeeSelectorComponent} from './components/burst-fee-selector/burst-f
     FormsModule,
     MatFormFieldModule,
     CommonModule,
-    MatInputModule
+    MatInputModule,
+    FlexModule
   ],
   exports: [
     VerticalLayout1Module,

--- a/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.html
+++ b/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.html
@@ -1,18 +1,15 @@
 <form (ngSubmit)="onSubmit($event);" #sendBurstForm="ngForm">
-  <mat-form-field appearance="outline">
-    <input matInput prefix="BURST-" burstInputValidator [patterns]="burstAddressPatternRef" mask="____-____-____-_____"
-           [dropSpecialCharacters]="false" [showMaskTyped]="true" [(ngModel)]="recipientAddress" name="recipientAddress"
-           placeholder="{{ 'recipient' | i18n }}">
-  </mat-form-field>
+
+  <burst-recipient-input (recipientChange)="onRecipientChange($event)"></burst-recipient-input>
 
   <mat-grid-list cols="2" rowHeight="85px" gutterSize="10px">
     <mat-grid-tile>
-      <mat-form-field appearance="outline">
+      <mat-form-field>
         <input matInput [(ngModel)]="amountNQT" name="amountNQT" placeholder="{{ 'amount' | i18n }}">
       </mat-form-field>
     </mat-grid-tile>
     <mat-grid-tile *ngIf="feeNQT">
-      <mat-form-field appearance="outline">
+      <mat-form-field>
         <input matInput [(ngModel)]="feeNQT" name="feeNQT" placeholder="{{ 'fee' | i18n }}">
       </mat-form-field>
     </mat-grid-tile>
@@ -23,36 +20,36 @@
   <mat-checkbox (click)="showMessage=!showMessage">{{ "add_message_q" | i18n }}</mat-checkbox>
 
   <div *ngIf="showMessage">
-    <mat-form-field appearance="outline">
+    <mat-form-field>
       <textarea matInput [(ngModel)]="message" name="message" placeholder="{{ 'message' | i18n }}"></textarea>
     </mat-form-field>
     <mat-checkbox [(ngModel)]="encrypt" name="encrypt">{{ "encrypt_message" | i18n }}</mat-checkbox>
   </div>
 
   <div *ngIf="advanced">
-    <mat-form-field appearance="outline">
+    <mat-form-field>
       <label>{{ 'deadline_hours' | i18n }}</label>
       <input matInput [(ngModel)]="deadline" name="deadline" placeholder="{{ 'deadline_hours' | i18n }}">
     </mat-form-field>
 
-<!--    FUTURE FEATURE-->
-<!--
-    <mat-form-field appearance="outline">
-      <input matInput [(ngModel)]="fullHash" name="fullHash"
-             placeholder="{{ 'referenced_transaction_full_hash' | i18n }}" disabled>
-    </mat-form-field>
+    <!--    FUTURE FEATURE-->
+    <!--
+        <mat-form-field >
+          <input matInput [(ngModel)]="fullHash" name="fullHash"
+                 placeholder="{{ 'referenced_transaction_full_hash' | i18n }}" disabled>
+        </mat-form-field>
 
-    <mat-checkbox [(ngModel)]="broadcast" name="broadcast" disabled>{{ "do_not_broadcast" | i18n }}</mat-checkbox>
-    <br/>
+        <mat-checkbox [(ngModel)]="broadcast" name="broadcast" disabled>{{ "do_not_broadcast" | i18n }}</mat-checkbox>
+        <br/>
 
-    <mat-checkbox [(ngModel)]="note" name="note" disabled>{{ "add_note_to_self_q" | i18n }}</mat-checkbox>
+        <mat-checkbox [(ngModel)]="note" name="note" disabled>{{ "add_note_to_self_q" | i18n }}</mat-checkbox>
 
-    <div *ngIf="note">
-      <mat-form-field appearance="outline">
-        <textarea matInput [(ngModel)]="note_text" name="note_text" placeholder="{{ 'note' | i18n }}"></textarea>
-      </mat-form-field>
-    </div>
--->
+        <div *ngIf="note">
+          <mat-form-field >
+            <textarea matInput [(ngModel)]="note_text" name="note_text" placeholder="{{ 'note' | i18n }}"></textarea>
+          </mat-form-field>
+        </div>
+    -->
   </div>
 
   <div class="send-button-wrapper">

--- a/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.spec.ts
+++ b/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.spec.ts
@@ -1,6 +1,6 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { NetworkModule } from 'app/network/network.module';
+import {NetworkModule} from 'app/network/network.module';
 import {
   MatCheckboxModule,
   MatGridListModule,
@@ -12,25 +12,26 @@ import {
   MatSelectModule,
   MatProgressSpinnerModule, MatTooltipModule
 } from '@angular/material';
-import { I18nModule } from 'app/layout/components/i18n/i18n.module';
-import { NgxMaskModule } from 'ngx-mask';
-import { NotifierModule } from 'angular-notifier';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BrowserModule } from '@angular/platform-browser';
-import { I18nService } from 'app/layout/components/i18n/i18n.service';
-import { StoreService } from 'app/store/store.service';
-import { BehaviorSubject } from 'rxjs';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { FormsModule } from '@angular/forms';
-import { BurstFeeSelectorComponent } from 'app/layout/components/burst-fee-selector/burst-fee-selector.component';
-import { Ng5SliderModule } from 'ng5-slider';
+import {I18nModule} from 'app/layout/components/i18n/i18n.module';
+import {NgxMaskModule} from 'ngx-mask';
+import {NotifierModule} from 'angular-notifier';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {BrowserModule} from '@angular/platform-browser';
+import {I18nService} from 'app/layout/components/i18n/i18n.service';
+import {StoreService} from 'app/store/store.service';
+import {BehaviorSubject} from 'rxjs';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {FormsModule} from '@angular/forms';
+import {BurstFeeSelectorComponent} from 'app/layout/components/burst-fee-selector/burst-fee-selector.component';
+import {BurstRecipientInputComponent} from 'app/layout/components/burst-recipient-input/burst-recipient-input.component';
+import {Ng5SliderModule} from 'ng5-slider';
 
 
-import { SendBurstFormComponent } from './send-burst-form.component';
-import { BurstInputValidatorDirective } from '../send-burst-validator.directive';
-import { TransactionService } from 'app/main/transactions/transaction.service';
-import { AccountService } from 'app/setup/account/account.service';
-import { Account } from '@burstjs/core';
+import {SendBurstFormComponent} from './send-burst-form.component';
+import {BurstInputValidatorDirective} from '../send-burst-validator.directive';
+import {TransactionService} from 'app/main/transactions/transaction.service';
+import {AccountService} from 'app/setup/account/account.service';
+import {Account} from '@burstjs/core';
 
 describe('SendBurstFormComponent', () => {
   let component: SendBurstFormComponent;
@@ -59,7 +60,12 @@ describe('SendBurstFormComponent', () => {
         HttpClientTestingModule,
         MatProgressSpinnerModule
       ],
-      declarations: [ SendBurstFormComponent, BurstInputValidatorDirective, BurstFeeSelectorComponent ],
+      declarations: [
+        SendBurstFormComponent,
+        BurstInputValidatorDirective,
+        BurstFeeSelectorComponent,
+        BurstRecipientInputComponent
+      ],
       providers: [
         I18nService,
         {
@@ -91,7 +97,7 @@ describe('SendBurstFormComponent', () => {
         BurstInputValidatorDirective
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.ts
+++ b/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.ts
@@ -1,10 +1,11 @@
 import {Component, OnInit, ViewChild, Input} from '@angular/core';
-import {SuggestedFees, Account, EncryptedMessage} from '@burstjs/core';
-import {burstAddressPattern, isBurstAddress} from '@burstjs/util';
+import {SuggestedFees, Account} from '@burstjs/core';
+import {burstAddressPattern} from '@burstjs/util';
 import {NgForm} from '@angular/forms';
 import {TransactionService} from 'app/main/transactions/transaction.service';
 import {NotifierService} from 'angular-notifier';
 import {I18nService} from 'app/layout/components/i18n/i18n.service';
+import {AccountService} from '../../../setup/account/account.service';
 
 
 const isNotEmpty = (value: string) => value && value.length > 0;
@@ -16,7 +17,6 @@ const isNotEmpty = (value: string) => value && value.length > 0;
 })
 export class SendBurstFormComponent implements OnInit {
   @ViewChild('sendBurstForm') public sendBurstForm: NgForm;
-  @ViewChild('recipientAddress') public recipientAddress: string;
   @ViewChild('amountNQT') public amountNQT: string;
   @ViewChild('message') public message: string;
   @ViewChild('fullHash') public fullHash: string;
@@ -31,11 +31,13 @@ export class SendBurstFormComponent implements OnInit {
   burstAddressPatternRef = burstAddressPattern;
   deadline = '24';
 
+  public recipient: string;
   public feeNQT: string;
   isSending = false;
 
   constructor(
     private transactionService: TransactionService,
+    private accountService: AccountService,
     private notifierService: NotifierService,
     private i18nService: I18nService) {
   }
@@ -63,7 +65,7 @@ export class SendBurstFormComponent implements OnInit {
         },
         pin: this.pin,
         keys: this.account.keys,
-        recipientAddress: `BURST-${this.recipientAddress}`
+        recipientAddress: this.recipient
       });
 
       this.notifierService.notify('success', this.i18nService.getTranslation('success_send_money'));
@@ -92,10 +94,15 @@ export class SendBurstFormComponent implements OnInit {
     };
   }
 
-
   canSubmit(): boolean {
-    return isBurstAddress(`BURST-${this.recipientAddress}`) &&
+    return isNotEmpty(this.recipient) &&
       isNotEmpty(this.amountNQT) &&
       isNotEmpty(this.pin);
+  }
+
+
+  onRecipientChange(recipientRS: string): void {
+    console.log(recipientRS);
+    this.recipient = recipientRS;
   }
 }

--- a/web/angular-wallet/src/app/main/send-burst/send-burst.component.spec.ts
+++ b/web/angular-wallet/src/app/main/send-burst/send-burst.component.spec.ts
@@ -30,6 +30,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { TransactionService } from '../transactions/transaction.service';
 import { AccountService } from 'app/setup/account/account.service';
 import { BurstFeeSelectorComponent } from 'app/layout/components/burst-fee-selector/burst-fee-selector.component';
+import { BurstRecipientInputComponent } from 'app/layout/components/burst-recipient-input/burst-recipient-input.component';
 import { Ng5SliderModule } from 'ng5-slider';
 import { SendBurstFormComponent } from './send-burst-form/send-burst-form.component';
 import { SendMultiOutFormComponent } from './send-multi-out-form/send-multi-out-form.component';
@@ -65,7 +66,14 @@ describe('SendBurstComponent', () => {
         ),
         MatProgressSpinnerModule
       ],
-      declarations: [ SendBurstComponent, BurstInputValidatorDirective, BurstFeeSelectorComponent, SendBurstFormComponent, SendMultiOutFormComponent ],
+      declarations: [
+        SendBurstComponent,
+        BurstInputValidatorDirective,
+        BurstFeeSelectorComponent,
+        SendBurstFormComponent,
+        SendMultiOutFormComponent,
+        BurstRecipientInputComponent
+      ],
       providers: [
         I18nService,
         {

--- a/web/angular-wallet/src/app/main/send-burst/send-burst.module.ts
+++ b/web/angular-wallet/src/app/main/send-burst/send-burst.module.ts
@@ -11,7 +11,7 @@ import {
   MatCheckboxModule,
   MatAutocompleteModule,
   MatTabsModule,
-  MatProgressSpinnerModule
+  MatProgressSpinnerModule, MatChipsModule, MatBadgeModule, MatTooltipModule
 } from '@angular/material';
 import { FormsModule } from '@angular/forms';
 import { SetupModule } from 'app/setup/setup.module';
@@ -60,7 +60,10 @@ const routes = [
     NetworkModule,
     LayoutModule,
     MatAutocompleteModule,
-    RouterModule.forChild(routes)
+    RouterModule.forChild(routes),
+    MatChipsModule,
+    MatBadgeModule,
+    MatTooltipModule
   ],
   exports: [
     BurstInputValidatorDirective

--- a/web/angular-wallet/src/app/setup/account/account.service.ts
+++ b/web/angular-wallet/src/app/setup/account/account.service.ts
@@ -53,7 +53,7 @@ export class AccountService {
   private api: Api;
   private selectedNode: NodeDescriptor;
 
-  // a simple string cache of transaction ids for which the user 
+  // a simple string cache of transaction ids for which the user
   // has already received a push notification
   private transactionsSeenInNotifications: string[] = [];
 
@@ -90,6 +90,9 @@ export class AccountService {
       feeNQT,
       immutable
     );
+  }
+  public getAlias(name: string): Promise<any>{
+    return this.api.alias.getAliasByName(name);
   }
 
   public getAliases(id: string): Promise<AliasList> {
@@ -228,11 +231,11 @@ export class AccountService {
     this.transactionsSeenInNotifications[transaction.transaction] = true;
     const incoming = transaction.recipientRS === this.currentAccount.value.accountRS;
     // @ts-ignore
-    return window.Notification && new window.Notification(incoming ? 
+    return window.Notification && new window.Notification(incoming ?
       this.i18nService.getTranslation('youve_got_burst') :
-      this.i18nService.getTranslation('you_sent_burst'), 
-      { 
-        body: `${convertNQTStringToNumber(transaction.amountNQT)} BURST`, 
+      this.i18nService.getTranslation('you_sent_burst'),
+      {
+        body: `${convertNQTStringToNumber(transaction.amountNQT)} BURST`,
         title: 'Phoenix'
       });
 
@@ -243,7 +246,7 @@ export class AccountService {
       const unconfirmedTransactionsResponse = await this.getUnconfirmedTransactions(account.account);
       account.transactions = unconfirmedTransactionsResponse.unconfirmedTransactions
         .concat(account.transactions);
-                
+
       // @ts-ignore - Send notifications for new transactions
       if (window.Notification) {
         unconfirmedTransactionsResponse.unconfirmedTransactions


### PR DESCRIPTION
Introduced a recipient component with validity checks for sending burst

![Peek 2019-05-04 19-36](https://user-images.githubusercontent.com/3920663/57185552-0212f700-6ea4-11e9-9324-84b7f96f9ee7.gif)


Partially fixes #219 

> Needs to apply for multi-out, and need override in for non-existing accounts
