### PR TITLE
layout enhancements for balance history chart

### DIFF
--- a/web/angular-wallet/src/app/main/dashboard/balance-diagram/balance-diagram.component.html
+++ b/web/angular-wallet/src/app/main/dashboard/balance-diagram/balance-diagram.component.html
@@ -24,6 +24,7 @@
   </div>
 
   <div class="controls">
+    <p class="font-size-14 secondary-text pr-16">Recent transactions since {{firstDate | date:'MMM d, y, h:mm:ss'}}</p>
     <mat-form-field >
       <mat-label>No. Transactions</mat-label>
       <mat-select [(value)]="transactionCount" (selectionChange)="onItemCountSelected()">

--- a/web/angular-wallet/src/app/main/dashboard/balance-diagram/balance-diagram.component.scss
+++ b/web/angular-wallet/src/app/main/dashboard/balance-diagram/balance-diagram.component.scss
@@ -15,7 +15,8 @@
   .controls {
     display: flex;
     flex-direction: row;
-    justify-content: flex-end;
+    justify-content: space-between;
+
     mat-form-field{
       width: 80px;
       font-size: 12px

--- a/web/angular-wallet/src/app/main/dashboard/balance-diagram/balance-diagram.component.ts
+++ b/web/angular-wallet/src/app/main/dashboard/balance-diagram/balance-diagram.component.ts
@@ -1,7 +1,7 @@
 import {Router} from '@angular/router';
 import {Component, Input, OnChanges} from '@angular/core';
-import {Transaction, Account} from '@burstjs/core';
-import {convertNQTStringToNumber} from '@burstjs/util';
+import {Account} from '@burstjs/core';
+import {convertBurstTimeToDate, convertNQTStringToNumber} from '@burstjs/util';
 import * as shape from 'd3-shape';
 import {getBalanceHistoryFromTransactions} from '../../../util/balance/getBalanceHistoryFromTransactions';
 import {BalanceHistoryItem} from '../../../util/balance/typings';
@@ -17,39 +17,57 @@ class ChartOptions {
   };
 }
 
+const TransactionCountOptions = [25, 50, 100, 250, 500];
+
 @Component({
   selector: 'app-balance-diagram',
   templateUrl: './balance-diagram.component.html',
   styleUrls: ['./balance-diagram.component.scss']
 })
-export class BalanceDiagramComponent implements OnChanges{
+export class BalanceDiagramComponent implements OnChanges {
 
   @Input() public account: Account;
   @Input() public transactionCount?: number;
   public options = new ChartOptions();
   public data: any[];
   private balanceHistory: BalanceHistoryItem[];
-
-  itemCountOptions = [25, 50, 100, 250, 500].map(i => ({
-      value: i, viewValue: i
-    })
-  );
+  itemCountOptions: Array<any>;
+  firstDate: Date;
 
   constructor(private router: Router) {
-    this.transactionCount = 20;
+    this.transactionCount = 0;
   }
 
   async ngOnChanges(): Promise<void> {
-    this.updateDiagram(this.account.transactions.slice(0, this.transactionCount));
+    this.itemCountOptions = this.getMaximumItemCountOptions();
+    this.updateDiagram();
   }
 
-  private updateDiagram(transactions: Transaction[]): void {
+  private getMaximumItemCountOptions(): Array<number> {
+
+    const transactionCountMax = this.account.transactions.length;
+    const availableOptions = [];
+    for (let i = 0; i < TransactionCountOptions.length; ++i) {
+      const transactionCount = TransactionCountOptions[i];
+      const option = {value: transactionCount, viewValue: transactionCount};
+      availableOptions.push(option);
+      if (transactionCount > transactionCountMax) {
+        break;
+      }
+    }
+    return availableOptions;
+  }
+
+  private updateDiagram(): void {
+    const transactions = this.account.transactions.slice(0, this.transactionCount);
     const {account, balanceNQT} = this.account;
 
     this.balanceHistory = getBalanceHistoryFromTransactions(
       account,
       convertNQTStringToNumber(balanceNQT),
       transactions).reverse();
+
+    this.firstDate = convertBurstTimeToDate(this.balanceHistory[0].timestamp);
 
     this.data = [
       {
@@ -63,7 +81,7 @@ export class BalanceDiagramComponent implements OnChanges{
   }
 
   onItemCountSelected(): void {
-    this.updateDiagram(this.account.transactions.slice(0, this.transactionCount));
+    this.updateDiagram();
   }
 
   onSelect($event: any): void {

--- a/web/angular-wallet/src/app/util/balance/getBalanceHistoryFromTransactions.ts
+++ b/web/angular-wallet/src/app/util/balance/getBalanceHistoryFromTransactions.ts
@@ -36,6 +36,7 @@ export function getBalanceHistoryFromTransactions(
   return transactions.map((t: Transaction) => {
     const relativeAmount = getRelativeTransactionAmount(accountId, t);
     const deducedBalances = {
+      timestamp: t.blockTimestamp,
       transactionId: t.transaction,
       balance,
       transaction: t

--- a/web/angular-wallet/src/app/util/balance/typings.ts
+++ b/web/angular-wallet/src/app/util/balance/typings.ts
@@ -1,6 +1,7 @@
 import {Transaction} from '@burstjs/core';
 
 export interface BalanceHistoryItem {
+  readonly timestamp: number;
   readonly transactionId: string;
   readonly balance: number;
   readonly transaction: Transaction;


### PR DESCRIPTION
- Limiting options in dropdown to "one level" above maximum available transactions
- Showing label with date of first transaction in chart
![balance](https://user-images.githubusercontent.com/3920663/57346988-1adf0f00-7127-11e9-96e2-0ef02178ebda.gif)

