### PR TITLE
Fix/new account

### DIFF
--- a/web/angular-wallet/proxy.config.json
+++ b/web/angular-wallet/proxy.config.json
@@ -1,6 +1,6 @@
 {
   "/burst": {
-    "target": "https://wallet1.burst-team.us:2083",
+    "target": "http://testnet.getburst.net:6876",
     "changeOrigin": true,
     "secure": false,
     "logLevel": "info"

--- a/web/angular-wallet/proxy.config.json
+++ b/web/angular-wallet/proxy.config.json
@@ -1,6 +1,6 @@
 {
   "/burst": {
-    "target": "http://testnet.getburst.net:6876",
+    "target": "https://wallet1.burst-team.us:2083",
     "changeOrigin": true,
     "secure": false,
     "logLevel": "info"

--- a/web/angular-wallet/src/app/login/login-active/login-active.component.html
+++ b/web/angular-wallet/src/app/login/login-active/login-active.component.html
@@ -5,11 +5,11 @@
       </a>
   </header>
   <div class="signup__container">
-      <h1 *ngIf="newUser | async; else updateTitle" class="signup__title">Create a new burst account</h1>
+      <h1 *ngIf="newUser | async; else updateTitle" class="signup__title">{{ 'create_your_account' | i18n }}</h1>
       <app-account-create [newUser]="newUser | async"></app-account-create>
   </div>
 </div>
 
 <ng-template #updateTitle>
-  <h1 class="signup__title">Update your burst account</h1>
+  <h1 class="signup__title">{{ 'update_burst_account' | i18n }}</h1>
 </ng-template>

--- a/web/angular-wallet/src/app/login/login-active/login-active.component.spec.ts
+++ b/web/angular-wallet/src/app/login/login-active/login-active.component.spec.ts
@@ -2,9 +2,13 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { LoginActiveComponent } from './login-active.component';
 import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
+import { of, BehaviorSubject } from 'rxjs';
 import { MockComponent } from 'ng-mocks';
 import { CreateActiveAccountComponent } from 'app/setup/account/create-active/create.component';
+import { I18nModule } from 'app/layout/components/i18n/i18n.module';
+import { StoreService } from 'app/store/store.service';
+import { I18nService } from 'app/layout/components/i18n/i18n.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('LoginActiveComponent', () => {
   let component: LoginActiveComponent;
@@ -13,13 +17,26 @@ describe('LoginActiveComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes([])
+        HttpClientTestingModule,
+        RouterTestingModule.withRoutes([]),
+        I18nModule
       ],
       declarations: [
         LoginActiveComponent,
         MockComponent(CreateActiveAccountComponent)
       ],
       providers: [
+        I18nService,
+        {
+          provide: StoreService,
+          useFactory: () => {
+            return {
+              ready: new BehaviorSubject(true),
+              getSettings: () => Promise.resolve({ language: 'en' }),
+              saveSettings: () => Promise.resolve(true)
+            };
+          }
+        },
         {
           provide: ActivatedRoute,
           useValue: {

--- a/web/angular-wallet/src/app/login/login-passive/login-passive.component.spec.ts
+++ b/web/angular-wallet/src/app/login/login-passive/login-passive.component.spec.ts
@@ -3,6 +3,11 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { LoginPassiveComponent } from './login-passive.component';
 import { MockComponent } from 'ng-mocks';
 import { CreatePassiveAccountComponent } from 'app/setup/account/create-passive/create-passive.component';
+import { BehaviorSubject } from 'rxjs';
+import { StoreService } from 'app/store/store.service';
+import { I18nService } from 'app/layout/components/i18n/i18n.service';
+import { I18nModule } from 'app/layout/components/i18n/i18n.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('LoginPassiveComponent', () => {
   let component: LoginPassiveComponent;
@@ -11,11 +16,26 @@ describe('LoginPassiveComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes([])
+        HttpClientTestingModule,
+        RouterTestingModule.withRoutes([]),
+        I18nModule
       ],
       declarations: [
         LoginPassiveComponent,
         MockComponent(CreatePassiveAccountComponent)
+      ],
+      providers: [
+        I18nService,
+        {
+          provide: StoreService,
+          useFactory: () => {
+            return {
+              ready: new BehaviorSubject(true),
+              getSettings: () => Promise.resolve({ language: 'en' }),
+              saveSettings: () => Promise.resolve(true)
+            };
+          }
+        }
       ]})
       .compileComponents();
   }));

--- a/web/angular-wallet/src/app/login/login.component.html
+++ b/web/angular-wallet/src/app/login/login.component.html
@@ -11,7 +11,7 @@
       <p class="login__info">{{ 'new_user_text' | i18n }}</p>
       <div class="login__actions">
         <a class="login__link--yes" [routerLink]="[ '/login/active' ]" [queryParams]="{ newUser: true }">{{ 'new_user_yes' | i18n }}</a>
-        <a class="login__link--no" [routerLink]="[ '/login/active' ]" >{{ "new_user_no" | i18n }}</a>
+        <a class="login__link--no" [routerLink]="[ '/login/active' ]" >{{ 'new_user_no' | i18n }}</a>
         <p class="login__divider">{{ 'or' | i18n }}</p>
         <a class="login__link--default" [routerLink]="[ '/login/passive' ]" >{{ 'create_passive' | i18n }}</a>
       </div>

--- a/web/angular-wallet/src/app/login/login.component.html
+++ b/web/angular-wallet/src/app/login/login.component.html
@@ -7,13 +7,13 @@
       <small class="login__version">"Phoenix" Wallet ({{version}})</small>
     </div>
     <div class="login__body">
-      <h1 class="login__title">Get your free Burst account now.</h1>
-      <p class="login__info">Are you a new user? Create a new account and became a new Burst member.</p>
+      <h1 class="login__title">{{ 'get_burst_account' | i18n }}</h1>
+      <p class="login__info">{{ 'new_user_text' | i18n }}</p>
       <div class="login__actions">
-        <a class="login__link--yes" [routerLink]="[ '/login/active' ]" [queryParams]="{ newUser: true }">Yes, I'm a new user</a>
-        <a class="login__link--no" [routerLink]="[ '/login/active' ]" >No, I have an account</a>
-        <p class="login__divider">or</p>
-        <a class="login__link--default" [routerLink]="[ '/login/passive' ]" >Create a new account without passphrase</a>
+        <a class="login__link--yes" [routerLink]="[ '/login/active' ]" [queryParams]="{ newUser: true }">{{ 'new_user_yes' | i18n }}</a>
+        <a class="login__link--no" [routerLink]="[ '/login/active' ]" >{{ "new_user_no" | i18n }}</a>
+        <p class="login__divider">{{ 'or' | i18n }}</p>
+        <a class="login__link--default" [routerLink]="[ '/login/passive' ]" >{{ 'create_passive' | i18n }}</a>
       </div>
     </div>
   </div>

--- a/web/angular-wallet/src/app/main/dashboard/balance-diagram/balance-diagram.component.ts
+++ b/web/angular-wallet/src/app/main/dashboard/balance-diagram/balance-diagram.component.ts
@@ -67,7 +67,7 @@ export class BalanceDiagramComponent implements OnChanges {
       convertNQTStringToNumber(balanceNQT),
       transactions).reverse();
 
-    this.firstDate = convertBurstTimeToDate(this.balanceHistory[0].timestamp);
+    this.firstDate = this.balanceHistory.length && convertBurstTimeToDate(this.balanceHistory[0].timestamp);
 
     this.data = [
       {

--- a/web/angular-wallet/src/app/main/dashboard/dashboard.component.html
+++ b/web/angular-wallet/src/app/main/dashboard/dashboard.component.html
@@ -3,7 +3,7 @@
   <div class="content">
 
     <div class="mr-lg-32" fxFlex="100" *ngIf="account">
-      <mat-toolbar-row *ngIf="!account.confirmed && settings.welcomeMessageHiddenFrom.indexOf(account.account) === -1">
+      <mat-toolbar-row *ngIf="!account.confirmed && settings.welcomeMessageHiddenFrom.indexOf(account.account) === -1 && !account.balanceNQT">
         <mat-icon>card_giftcard</mat-icon>
         <span>{{ 'welcome_to_burst' | i18n }} <a href="http://faucet.burst-alliance.org:8080"
                                                  target="_blank">{{ 'click_to_claim' | i18n }}</a></span>
@@ -32,7 +32,10 @@
             <div class="p-16" fxLayout="column wrap" fxLayoutAlign="center">
               <div style="width: 100%">
                 <div class="h3 secondary-text">{{ 'balance_history' | i18n }}</div>
-                <div [ngClass.gt-md]="'font-size-54'" class="font-size-30 font-weight-300 line-height-1 mt-8">
+                <div *ngIf="!account.transactions.length">
+                  {{ 'no_transactions_yet' | i18n }}
+                </div>
+                <div *ngIf="account.transactions.length" [ngClass.gt-md]="'font-size-54'" class="font-size-30 font-weight-300 line-height-1 mt-8">
                   <app-balance-diagram
                     [account]="account"
                     [transactionCount]="50"

--- a/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.ts
+++ b/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.ts
@@ -1,6 +1,6 @@
 import {Component, Input, OnInit, ViewChild} from '@angular/core';
 import {Account, SuggestedFees} from '@burstjs/core';
-import {burstAddressPattern, convertNumericIdToAddress} from '@burstjs/util';
+import {burstAddressPattern} from '@burstjs/util';
 import {NgForm} from '@angular/forms';
 import {TransactionService} from 'app/main/transactions/transaction.service';
 import {NotifierService} from 'angular-notifier';
@@ -63,7 +63,7 @@ export class SendBurstFormComponent implements OnInit {
       const dialogRef = this.openWarningDialog([this.recipient]);
       dialogRef.afterClosed().subscribe(ok => {
         if (ok) {
-          this.sendBurst(convertNumericIdToAddress(this.recipient.addressRaw));
+          this.sendBurst(this.recipient.addressRaw);
         }
       });
     } else {

--- a/web/angular-wallet/src/app/main/send-burst/warn-send-dialog/warn-send-dialog.component.html
+++ b/web/angular-wallet/src/app/main/send-burst/warn-send-dialog/warn-send-dialog.component.html
@@ -1,7 +1,7 @@
 <div class="warn-dialog">
-  <h1 mat-dialog-title>Non-valid Recipients Detected</h1>
+  <h1 mat-dialog-title>{{ 'unknown_recipients' | i18n }}</h1>
   <div mat-dialog-content>
-    <p>The following recipient(s) could not be validated:</p>
+    <p>{{ 'unknown_recipients_text' | i18n }}</p>
     <ul class="recipient-list">
       <li *ngFor="let recipient of recipients">
         <div>
@@ -9,11 +9,11 @@
         </div>
       </li>
     </ul>
-    <p *ngIf="!hasUnknownAliasAccount">Do you you really want to send Burst to them?</p>
+    <p *ngIf="!hasUnknownAliasAccount">{{ 'are_you_sure' | i18n }}</p>
   </div>
   <div mat-dialog-actions>
-    <button *ngIf="hasUnknownAliasAccount" mat-button [mat-dialog-close]>Ok, Thanks</button>
-    <button *ngIf="!hasUnknownAliasAccount" mat-button [mat-dialog-close]>No, Thanks</button>
-    <button *ngIf="!hasUnknownAliasAccount" mat-button [mat-dialog-close]="true" color="accent">Yes, I'm sure!</button>
+    <button *ngIf="hasUnknownAliasAccount" mat-button [mat-dialog-close]>{{ 'close' | i18n }}</button>
+    <button *ngIf="!hasUnknownAliasAccount" mat-button [mat-dialog-close]>{{ 'cancel' | i18n }}</button>
+    <button *ngIf="!hasUnknownAliasAccount" mat-button [mat-dialog-close]="true" color="accent">{{ 'submit' | i18n }}</button>
   </div>
 </div>

--- a/web/angular-wallet/src/app/setup/account/create-active/create.component.html
+++ b/web/angular-wallet/src/app/setup/account/create-active/create.component.html
@@ -1,6 +1,6 @@
 <mat-horizontal-stepper #stepper [linear]="true" [selectedIndex]="this.createService.getStepIndex()" labelPosition="bottom">
     <mat-step [completed]="this.createService.isPassphraseGenerated()" [editable]="!this.createService.isPassphraseGenerated()">
-        <ng-template matStepLabel>Seed</ng-template>
+        <ng-template matStepLabel>{{ 'generate' | i18n }}</ng-template>
         <div class="step-container">
             <ng-container *ngIf="newUser">
                 <app-account-create-seed></app-account-create-seed>
@@ -11,13 +11,13 @@
         </div>
     </mat-step>
     <mat-step [completed]="this.createService.getAddress() != undefined && this.createService.getId() != undefined">
-        <ng-template matStepLabel>Record</ng-template>
+        <ng-template matStepLabel>{{ 'record' | i18n }}</ng-template>
         <div class="step-container">
             <app-account-create-record></app-account-create-record>
         </div>
     </mat-step>
     <mat-step>
-        <ng-template matStepLabel>Verify</ng-template>
+        <ng-template matStepLabel>{{ 'verify' | i18n }}</ng-template>
         <div class="step-container">
             <app-account-create-pin></app-account-create-pin>
         </div>

--- a/web/angular-wallet/src/app/setup/account/create-active/record/record.component.html
+++ b/web/angular-wallet/src/app/setup/account/create-active/record/record.component.html
@@ -12,7 +12,7 @@
     </tr>
     <tr>
         <td class="table__label">
-            Address:
+            {{ 'address' | i18n }}:
         </td>
         <td class="table__text">
             {{ this.createService.getAddress() }}
@@ -20,7 +20,7 @@
     </tr>
     <tr>
         <td class="table__label">
-            Passphrase:
+            {{ 'passphrase' | i18n }}:
         </td>
         <td class="table__text unselectable">
             {{ this.createService.getCompletePassphrase() }}
@@ -31,9 +31,7 @@
     </tr>
 </table>
 <hr class="divider">
-<small>
-    Note down your passphrase. The passphrase is the master key to your account. Therefore, keep your passphrase always safe and private!
-</small>
+<small>{{ 'memorize_passphrase_help' | i18n }}</small>
 <div class="text-center navigation">
     <button class="btn-danger" mat-raised-button (click)="reset()">Back</button>
     <button class="btn-success" mat-raised-button (click)="next()">Next</button>

--- a/web/angular-wallet/src/locales/bg.json
+++ b/web/angular-wallet/src/locales/bg.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/bg.json
+++ b/web/angular-wallet/src/locales/bg.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Вие предлагате този псевдоним за продажба.",
   "your_name": "Вашето име",
   "your_passphrase": "Вашата парола",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/bg.json
+++ b/web/angular-wallet/src/locales/bg.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/ca.json
+++ b/web/angular-wallet/src/locales/ca.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Has posat aquest Àlies a la venta.",
   "your_name": "El vostre nom",
   "your_passphrase": "La vostre Contrasenya",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/ca.json
+++ b/web/angular-wallet/src/locales/ca.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/ca.json
+++ b/web/angular-wallet/src/locales/ca.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/cs.json
+++ b/web/angular-wallet/src/locales/cs.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/cs.json
+++ b/web/angular-wallet/src/locales/cs.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/cs.json
+++ b/web/angular-wallet/src/locales/cs.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Nabízíte tento alias na prodej.",
   "your_name": "Vaše jméno",
   "your_passphrase": "Vaše heslo",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/de-de.json
+++ b/web/angular-wallet/src/locales/de-de.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/de-de.json
+++ b/web/angular-wallet/src/locales/de-de.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Sie bieten diesen Alias zum Kauf an.",
   "your_name": "Ihr Name",
   "your_passphrase": "Ihre Passphrase",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/de-de.json
+++ b/web/angular-wallet/src/locales/de-de.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/el.json
+++ b/web/angular-wallet/src/locales/el.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Προσφέρετε προς πώληση αυτό το ψευδώνυμο.",
   "your_name": "Το όνομά σου",
   "your_passphrase": "Η φράση πρόσβασης σας",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/el.json
+++ b/web/angular-wallet/src/locales/el.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/el.json
+++ b/web/angular-wallet/src/locales/el.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/en.json
+++ b/web/angular-wallet/src/locales/en.json
@@ -929,5 +929,17 @@
   "your_alias_sale_offer": "You are offering this alias for sale.",
   "your_name": "Your Name",
   "your_passphrase": "Your Passphrase",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
 }

--- a/web/angular-wallet/src/locales/en.json
+++ b/web/angular-wallet/src/locales/en.json
@@ -932,7 +932,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/es-es.json
+++ b/web/angular-wallet/src/locales/es-es.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Ha puesto este alias a la venta.",
   "your_name": "Su Nombre",
   "your_passphrase": "Su Contraseña",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/es-es.json
+++ b/web/angular-wallet/src/locales/es-es.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/es-es.json
+++ b/web/angular-wallet/src/locales/es-es.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/fi.json
+++ b/web/angular-wallet/src/locales/fi.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/fi.json
+++ b/web/angular-wallet/src/locales/fi.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Tarjoat tätä aliasta myytäväksi.",
   "your_name": "Nimesi",
   "your_passphrase": "Tunnuslauseesi",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/fi.json
+++ b/web/angular-wallet/src/locales/fi.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/fr.json
+++ b/web/angular-wallet/src/locales/fr.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/fr.json
+++ b/web/angular-wallet/src/locales/fr.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/fr.json
+++ b/web/angular-wallet/src/locales/fr.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Vous avez mis cet alias en vente.",
   "your_name": "Votre nom",
   "your_passphrase": "Votre phrase de passe",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/gl.json
+++ b/web/angular-wallet/src/locales/gl.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Esta poñendo a venta este alias.",
   "your_name": "O seu nome",
   "your_passphrase": "O seu contrasinal",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/gl.json
+++ b/web/angular-wallet/src/locales/gl.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/gl.json
+++ b/web/angular-wallet/src/locales/gl.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/hi.json
+++ b/web/angular-wallet/src/locales/hi.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "You are offering this alias for sale.",
   "your_name": "Your Name",
   "your_passphrase": "Your Passphrase",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/hi.json
+++ b/web/angular-wallet/src/locales/hi.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/hi.json
+++ b/web/angular-wallet/src/locales/hi.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/hr.json
+++ b/web/angular-wallet/src/locales/hr.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/hr.json
+++ b/web/angular-wallet/src/locales/hr.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Ponudili ste ovaj pseudonim na prodaju.",
   "your_name": "Vaše ime",
   "your_passphrase": "Vaša lozinka",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/hr.json
+++ b/web/angular-wallet/src/locales/hr.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/id.json
+++ b/web/angular-wallet/src/locales/id.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/id.json
+++ b/web/angular-wallet/src/locales/id.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/id.json
+++ b/web/angular-wallet/src/locales/id.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Anda menawarkan alias ini untuk dijual.",
   "your_name": "Namamu",
   "your_passphrase": "Kata sandi",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/it.json
+++ b/web/angular-wallet/src/locales/it.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Stai per mettere in vendita questo alias.",
   "your_name": "Il tuo nome",
   "your_passphrase": "La tua Passphrase",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/it.json
+++ b/web/angular-wallet/src/locales/it.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/it.json
+++ b/web/angular-wallet/src/locales/it.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/ja.json
+++ b/web/angular-wallet/src/locales/ja.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "あなたはこのエイリアスを売りに出しています。",
   "your_name": "名前",
   "your_passphrase": "あなたのパスフレーズ",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/ja.json
+++ b/web/angular-wallet/src/locales/ja.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/ja.json
+++ b/web/angular-wallet/src/locales/ja.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/lt.json
+++ b/web/angular-wallet/src/locales/lt.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/lt.json
+++ b/web/angular-wallet/src/locales/lt.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/lt.json
+++ b/web/angular-wallet/src/locales/lt.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Jūs siūlote ši pseudonimą pardavimui.",
   "your_name": "Jūsų vardas",
   "your_passphrase": "Jūsų slaptažodis",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/nl.json
+++ b/web/angular-wallet/src/locales/nl.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/nl.json
+++ b/web/angular-wallet/src/locales/nl.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/nl.json
+++ b/web/angular-wallet/src/locales/nl.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "U biedt deze alias te koop aan.",
   "your_name": "Uw naam",
   "your_passphrase": "Uw wachtwoord/passphrase",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/pl.json
+++ b/web/angular-wallet/src/locales/pl.json
@@ -929,7 +929,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/pl.json
+++ b/web/angular-wallet/src/locales/pl.json
@@ -926,5 +926,18 @@
   "your_alias_sale_offer": "Ten alias został przez Ciebie wystawiony na sprzedaż.",
   "your_name": "Twoje imię",
   "your_passphrase": "Twoje hasło",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/pl.json
+++ b/web/angular-wallet/src/locales/pl.json
@@ -939,5 +939,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/pt-br.json
+++ b/web/angular-wallet/src/locales/pt-br.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/pt-br.json
+++ b/web/angular-wallet/src/locales/pt-br.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Você está oferecendo este pseudônimo para venda.",
   "your_name": "Seu nome",
   "your_passphrase": "Sua senha",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/pt-br.json
+++ b/web/angular-wallet/src/locales/pt-br.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/pt-pt.json
+++ b/web/angular-wallet/src/locales/pt-pt.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Você está oferecendo este alias para venda.",
   "your_name": "O Seu Nome",
   "your_passphrase": "A sua senha",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/pt-pt.json
+++ b/web/angular-wallet/src/locales/pt-pt.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/pt-pt.json
+++ b/web/angular-wallet/src/locales/pt-pt.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/ro.json
+++ b/web/angular-wallet/src/locales/ro.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/ro.json
+++ b/web/angular-wallet/src/locales/ro.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/ro.json
+++ b/web/angular-wallet/src/locales/ro.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Ai pus acest alias la vânzare.",
   "your_name": "Numele tău",
   "your_passphrase": "Parola ta",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/ru.json
+++ b/web/angular-wallet/src/locales/ru.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/ru.json
+++ b/web/angular-wallet/src/locales/ru.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/ru.json
+++ b/web/angular-wallet/src/locales/ru.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Вы предлагаете этот псевдоним для продажи.",
   "your_name": "Ваше имя",
   "your_passphrase": "Ваш пароль",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/sh.json
+++ b/web/angular-wallet/src/locales/sh.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/sh.json
+++ b/web/angular-wallet/src/locales/sh.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Ponudili ste ovaj pseudonim na prodaju.",
   "your_name": "Vaše ime",
   "your_passphrase": "Vaša lozinka",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/sh.json
+++ b/web/angular-wallet/src/locales/sh.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/sk.json
+++ b/web/angular-wallet/src/locales/sk.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Ponúkate tento alias na predaj.",
   "your_name": "Vaše Meno",
   "your_passphrase": "Vaše heslo",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/sk.json
+++ b/web/angular-wallet/src/locales/sk.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/sk.json
+++ b/web/angular-wallet/src/locales/sk.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/sr-cs.json
+++ b/web/angular-wallet/src/locales/sr-cs.json
@@ -905,7 +905,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/sr-cs.json
+++ b/web/angular-wallet/src/locales/sr-cs.json
@@ -903,5 +903,18 @@
     "you_sold_assets": "Prodali ste ili transferovali <a href='#' data-goto-asset='__asset__'>1 __name__ asset-a<\/a>.",
     "you_sold_assets_plural": "Prodali ste ili transferovali <a href='#' data-goto-asset='__asset__'>__count__ __name__asset-a<\/a>.",
   "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+,
   "you_sent_burst": "You sent Burst"
 }

--- a/web/angular-wallet/src/locales/sr.json
+++ b/web/angular-wallet/src/locales/sr.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/sr.json
+++ b/web/angular-wallet/src/locales/sr.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/sr.json
+++ b/web/angular-wallet/src/locales/sr.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Ви нудите овај алиас на продају.",
   "your_name": "Ваше Име",
   "your_passphrase": "Ваша Лозинка",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/tr.json
+++ b/web/angular-wallet/src/locales/tr.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/tr.json
+++ b/web/angular-wallet/src/locales/tr.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Bu rumuzu satışa sunuyorsunuz.",
   "your_name": "Your Name",
   "your_passphrase": "Your Passphrase",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/tr.json
+++ b/web/angular-wallet/src/locales/tr.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/uk.json
+++ b/web/angular-wallet/src/locales/uk.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/uk.json
+++ b/web/angular-wallet/src/locales/uk.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/uk.json
+++ b/web/angular-wallet/src/locales/uk.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "Ви пропонуєте цей псевдонім для продажу.",
   "your_name": "Твоє ім’я",
   "your_passphrase": "Ваша парольна фраза",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/zh-cn.json
+++ b/web/angular-wallet/src/locales/zh-cn.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "您的该别名正在出售。",
   "your_name": "您的名称",
   "your_passphrase": "您的密码",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/zh-cn.json
+++ b/web/angular-wallet/src/locales/zh-cn.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/zh-cn.json
+++ b/web/angular-wallet/src/locales/zh-cn.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }

--- a/web/angular-wallet/src/locales/zh-tw.json
+++ b/web/angular-wallet/src/locales/zh-tw.json
@@ -916,5 +916,18 @@
   "your_alias_sale_offer": "您的該別名正在出售。",
   "your_name": "您的名字",
   "your_passphrase": "您的密碼",
-  "youve_got_burst": "You've got Burst!"
+  "youve_got_burst": "You've got Burst!",
+  "update_burst_account": "Update your burst account",
+  "record": "Record",
+  "verify": "verify",
+  "unknown_recipients": "Unknown Recipients Detected",
+  "unknown_recipients_text": "The following recipient(s) could not be validated:",
+  "are_you_sure": "Do you you really want to send Burst to them?",
+  "get_burst_account": "Get your free Burst account now.",
+  "new_user_text": "Are you a new user? Create a new account and became a new Burst member.",
+  "new_user_yes": "Yes, I'm a new user",
+  "new_user_no": "No, I have an account",
+  "create_passive": "Create a new account without passphrase",
+  "or": "or"
+
 }

--- a/web/angular-wallet/src/locales/zh-tw.json
+++ b/web/angular-wallet/src/locales/zh-tw.json
@@ -919,7 +919,7 @@
   "youve_got_burst": "You've got Burst!",
   "update_burst_account": "Update your burst account",
   "record": "Record",
-  "verify": "verify",
+  "verify": "Verify",
   "unknown_recipients": "Unknown Recipients Detected",
   "unknown_recipients_text": "The following recipient(s) could not be validated:",
   "are_you_sure": "Do you you really want to send Burst to them?",

--- a/web/angular-wallet/src/locales/zh-tw.json
+++ b/web/angular-wallet/src/locales/zh-tw.json
@@ -929,5 +929,4 @@
   "new_user_no": "No, I have an account",
   "create_passive": "Create a new account without passphrase",
   "or": "or"
-
 }


### PR DESCRIPTION
Fixes an issue where sending Burst to a new account would go to the wrong account.

Also closes #403 and maybe #271 (there was a JS error in the balance history graph). 