### PR TITLE
using new file pattern for artifact names

### DIFF
--- a/desktop/wallet/electron-builder.json
+++ b/desktop/wallet/electron-builder.json
@@ -1,0 +1,54 @@
+{
+  "productName": "Phoenix Burst Wallet",
+  "appId": "org.burstcoin.phoenix",
+  "directories": {
+    "output": "release-builds",
+    "buildResources": "dist"
+  },
+  "files": [
+    "dist/**/*",
+    "node_modules/**/*",
+    "assets/**/*",
+    "package.json",
+    "main.js"
+  ],
+  "icon": "./assets/images/png/512x512.png",
+  "mac": {
+    "artifactName": "${os}-phoenix-burst-wallet.${version}.${ext}",
+    "publish": [
+      "github"
+    ],
+    "category": "public.app-category.finance"
+  },
+  "linux": {
+    "artifactName": "${os}-phoenix-burst-wallet.${version}.${ext}",
+    "target": [
+      "AppImage",
+      "deb",
+      "rpm",
+      "tar.gz"
+    ],
+    "publish": [
+      "github"
+    ],
+    "category": "Finance"
+  },
+  "win": {
+    "artifactName": "${os}-phoenix-burst-wallet.${version}.${ext}",
+    "target": [
+      "nsis",
+      "portable"
+    ],
+    "publish": [
+      "github"
+    ]
+  },
+  "nsis": {
+    "multiLanguageInstaller": true,
+    "oneClick": true,
+    "allowElevation": false,
+    "packElevateHelper": false,
+    "perMachine": false,
+    "artifactName": "${os}-phoenix-burst-wallet-setup.${version}.${ext}"
+  }
+}

--- a/desktop/wallet/package.json
+++ b/desktop/wallet/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/burst-apps-team/phoenix"
   },
   "license": "GPL-3.0",
-  "description": "The BURST coin desktop wallet",
+  "description": "The BurstCoin desktop wallet",
   "keywords": [
     "burst",
     "burstcoin",
@@ -29,7 +29,7 @@
     "build": "node ../../scripts/build.js --target desktop",
     "start": "cross-env NODE_ENV=develop && npm run build && electron .",
     "start:fast": "cross-env NODE_ENV=develop && electron .",
-    "pack": "npm run build && electron-builder -p 'never'",
+    "pack": "npm run build && electron-builder -p 'never' --config electron-builder.json",
     "release:all": "npm run pack -- -wml",
     "release:linux": "npm run pack -- -l",
     "release:win32": "npm run pack -- -w",
@@ -42,55 +42,5 @@
     "cross-env": "^5.2.0",
     "electron": "^5.0.1",
     "electron-builder": "^20.40.2"
-  },
-  "build": {
-    "productName": "Phoenix Burst Wallet",
-    "appId": "org.burstcoin.phoenix",
-    "directories": {
-      "output": "release-builds",
-      "buildResources": "dist"
-    },
-    "files": [
-      "dist/**/*",
-      "node_modules/**/*",
-      "assets/**/*",
-      "package.json",
-      "main.js"
-    ],
-    "icon": "./assets/images/png/512x512.png",
-    "mac": {
-      "publish": [
-        "github"
-      ],
-      "category": "public.app-category.finance"
-    },
-    "linux": {
-      "target": [
-        "AppImage",
-        "deb",
-        "rpm",
-        "tar.gz"
-      ],
-      "publish": [
-        "github"
-      ],
-      "category": "Finance"
-    },
-    "win": {
-      "target": [
-        "nsis",
-        "portable"
-      ],
-      "publish": [
-        "github"
-      ]
-    },
-    "nsis": {
-      "multiLanguageInstaller": true,
-      "oneClick": true,
-      "allowElevation": false,
-      "packElevateHelper": false,
-      "perMachine": false
-    }
   }
 }


### PR DESCRIPTION
Changed artifact names of released files to more "user-friendly" file name, like

`win-phoenix-burst-wallet-setup.1.0.0-beta.6.exe`
`linux-phoenix-burst-wallet.1.0.0-beta.6.AppImage`
`mac-phoenix-burst-wallet.1.0.0-beta.6.dmg`
