### PR TITLE
Add instructions to run the latest built release (linux)

### DIFF
--- a/desktop/wallet/README.md
+++ b/desktop/wallet/README.md
@@ -1,5 +1,16 @@
 # The Phoenix Desktop Wallet
 
+## Running the latest release (Linux)
+```console
+$ wget https://github.com/burst-apps-team/phoenix/releases/download/v1.0.0-beta.6/phoenix-1.0.0-beta.6.tar.gz
+$ tar zxvf phoenix-1.0.0-beta.6.tar.gz
+$ cd phoenix-1.0.0-beta.6/
+```
+```console
+$ sudo chown root:root ./chrome-sandbox
+$ sudo chmod 4755 ./chrome-sandbox
+$ ./phoenix
+```
 
 ## Build and Start Desktop Wallet
 


### PR DESCRIPTION
It took me a bit of digging to get Phoenix up and running on my system.

I ran into some issue about SUID, (described and solved in issue #313).

Some documentation to quickly get up and running without re-building from source would be great. Maybe we can link a quickstart area from the home README.md file as well?