### PR TITLE
 feat(web): add npm run build:web for web nodes

### DIFF
--- a/web/angular-wallet/angular.json
+++ b/web/angular-wallet/angular.json
@@ -58,6 +58,30 @@
                                 }
                             ]
                         },
+                        "web": {
+                            "fileReplacements": [
+                                {
+                                    "replace": "src/environments/environment.ts",
+                                    "with": "src/environments/environment.web.ts"
+                                }
+                            ],
+                            "optimization": true,
+                            "outputHashing": "all",
+                            "sourceMap": false,
+                            "extractCss": true,
+                            "namedChunks": false,
+                            "aot": true,
+                            "extractLicenses": true,
+                            "vendorChunk": false,
+                            "buildOptimizer": true,
+                            "budgets": [
+                                {
+                                    "type": "initial",
+                                    "maximumWarning": "2mb",
+                                    "maximumError": "5mb"
+                                }
+                            ]
+                        },
                         "ec": {
                             "sourceMap": true,
                             "extractCss": true

--- a/web/angular-wallet/package.json
+++ b/web/angular-wallet/package.json
@@ -16,6 +16,7 @@
     "build:ci": "npm run build -- --aot --source-map=false --stats-json",
     "build:stats": "npm run build -- --dev --stats-json",
     "build:prod": "npm run build -- --prod",
+    "build:web": "npm run build -- --configuration=web",
     "build:prod-stats": "npm run build -- --prod --stats-json",
     "test": "jest",
     "lint": "ng lint",

--- a/web/angular-wallet/proxy.config.json
+++ b/web/angular-wallet/proxy.config.json
@@ -4,15 +4,5 @@
     "changeOrigin": true,
     "secure": false,
     "logLevel": "info"
-  },
-  "/v1/ticker/burst": {
-    "target": "https://api.coinmarketcap.com/",
-    "secure": false,
-    "logLevel": "debug",
-    "headers": {
-      "Origin": "https://api.coinmarketcap.com",
-      "Host": "api.coinmarketcap.com",
-      "Content-type": "application/json"
-    }
   }
 }

--- a/web/angular-wallet/src/@fuse/scss/partials/_colors.scss
+++ b/web/angular-wallet/src/@fuse/scss/partials/_colors.scss
@@ -225,11 +225,11 @@ $matHues: 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, A100, A200, A400, A70
 // -----------------------------------------------------------------------------------------------------
 @mixin generate-color-classes($colorName, $color, $contrastColor, $hue) {
 
-    .#{$colorName}#{$hue}-bg {
+    .#{"" + $colorName}#{"" + $hue}-bg {
         background-color: $color !important;
     }
 
-    .#{$colorName}#{$hue} {
+    .#{"" + $colorName}#{"" + $hue} {
         background-color: $color !important;
         color: $contrastColor !important;
 
@@ -239,27 +239,27 @@ $matHues: 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, A100, A200, A400, A70
         }
     }
 
-    .#{$colorName}#{$hue}-fg {
+    .#{"" + $colorName}#{"" + $hue}-fg {
         color: $color !important;
     }
 
-    .#{$colorName}#{$hue}-border {
+    .#{"" + $colorName}#{"" + $hue}-border {
         border-color: $color !important;
     }
 
-    .#{$colorName}#{$hue}-border-top {
+    .#{"" + $colorName}#{"" + $hue}-border-top {
         border-top-color: $color !important;
     }
 
-    .#{$colorName}#{$hue}-border-right {
+    .#{"" + $colorName}#{"" + $hue}-border-right {
         border-right-color: $color !important;
     }
 
-    .#{$colorName}#{$hue}-border-bottom {
+    .#{"" + $colorName}#{"" + $hue}-border-bottom {
         border-bottom-color: $color !important;
     }
 
-    .#{$colorName}#{$hue}-border-left {
+    .#{"" + $colorName}#{"" + $hue}-border-left {
         border-left-color: $color !important;
     }
 }

--- a/web/angular-wallet/src/@fuse/services/match-media.service.ts
+++ b/web/angular-wallet/src/@fuse/services/match-media.service.ts
@@ -45,11 +45,13 @@ export class FuseMatchMediaService
                 distinctUntilChanged()
             )
             // @ts-ignore
-            .subscribe((change: MediaChange) => {
-                if ( this.activeMediaQuery !== change.mqAlias )
-                {
-                    this.activeMediaQuery = change.mqAlias;
-                    this.onMediaChange.next(change.mqAlias);
+            .subscribe((change: MediaChange[]) => {
+                if (!change || !change.length) {
+                    return;
+                }
+                if (this.activeMediaQuery !== change[0].mqAlias) {
+                    this.activeMediaQuery = change[0].mqAlias;
+                    this.onMediaChange.next(change[0].mqAlias);
                 }
             });
     }

--- a/web/angular-wallet/src/environments/environment.hmr.ts
+++ b/web/angular-wallet/src/environments/environment.hmr.ts
@@ -6,7 +6,7 @@ export const environment = {
   version,
   defaultNode: 'http://localhost:4200',
   market: {
-    tickerUrl: '/v1/ticker/burst/',
+    tickerUrl: 'https://api.coinmarketcap.com/v1/ticker/burst/',
     tickerInterval: 30 * 1000
   }
 };

--- a/web/angular-wallet/src/environments/environment.ts
+++ b/web/angular-wallet/src/environments/environment.ts
@@ -9,7 +9,7 @@ export const environment = {
   version,
   defaultNode: 'http://localhost:4200',
   market: {
-    tickerUrl: '/v1/ticker/burst/',
+    tickerUrl: 'https://api.coinmarketcap.com/v1/ticker/burst/',
     tickerInterval: 30 * 1000
   }
 };

--- a/web/angular-wallet/src/environments/environment.web.ts
+++ b/web/angular-wallet/src/environments/environment.web.ts
@@ -1,0 +1,12 @@
+import {version} from '../../package.json';
+
+export const environment = {
+  production: true,
+  hmr: false,
+  version,
+  defaultNode: '',
+  market: {
+    tickerUrl: 'https://api.coinmarketcap.com/v1/ticker/burst/',
+    tickerInterval: 30 * 1000
+  }
+};


### PR DESCRIPTION
- Places a build inside `/web/angular-wallet/dist`.
- defaultNode is blank
- To use this on a node, replace `html/ui` on your node with the contents of `/web/angular-wallet/dist` after running `npm run build:web` from inside `/web/angular-wallet`
- Also fixes all those CSS warnings