### PR TITLE
moved very ui specific burstAddressPattern to angular

### DIFF
--- a/lib/packages/util/src/index.ts
+++ b/lib/packages/util/src/index.ts
@@ -15,13 +15,3 @@ export * from './convertHexStringToDecString';
 export * from './convertHexStringToString';
 export * from './convertStringToByteArray';
 export * from './convertStringToHexString';
-
-
-/**
- * A useful regex for matching burst addresses
- *
- */
-    // TODO: I doubt that this should be in the lib. Very UI specific
-export const burstAddressPattern = {
-    '_': {pattern: new RegExp('\[a-zA-Z0-9\]')}
-};

--- a/web/angular-wallet/src/app/main/aliases/add-alias/add-alias.component.ts
+++ b/web/angular-wallet/src/app/main/aliases/add-alias/add-alias.component.ts
@@ -1,12 +1,11 @@
 import { Component, OnInit, ViewChild, Output, EventEmitter } from '@angular/core';
 import { SuggestedFees, Account } from '@burstjs/core';
 import { NgForm } from '@angular/forms';
-import { burstAddressPattern } from '@burstjs/util';
 import { ActivatedRoute } from '@angular/router';
 import { AccountService } from 'app/setup/account/account.service';
-import { StoreService } from 'app/store/store.service';
 import { NotifierService } from 'angular-notifier';
 import { I18nService } from 'app/layout/components/i18n/i18n.service';
+import {burstAddressPattern} from 'app/util/burstAddressPattern';
 
 @Component({
   selector: 'app-add-alias',

--- a/web/angular-wallet/src/app/main/messages/message-view/message-view.component.ts
+++ b/web/angular-wallet/src/app/main/messages/message-view/message-view.component.ts
@@ -19,7 +19,6 @@ import {AccountService} from 'app/setup/account/account.service';
 import {Account} from '@burstjs/core';
 import {Router} from '@angular/router';
 import {
-  burstAddressPattern,
   convertAddressToNumericId,
   isValid,
   convertDateToBurstTime,
@@ -29,6 +28,7 @@ import {NotifierService} from 'angular-notifier';
 import {UtilService} from 'app/util.service';
 import {I18nService} from 'app/layout/components/i18n/i18n.service';
 import {decryptAES, hashSHA256, decryptMessage} from '@burstjs/crypto';
+import {burstAddressPattern} from 'app/util/burstAddressPattern';
 
 @Component({
   selector: 'message-view',

--- a/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.ts
+++ b/web/angular-wallet/src/app/main/send-burst/send-burst-form/send-burst-form.component.ts
@@ -1,7 +1,7 @@
 import {Component, Input, OnInit, ViewChild, AfterViewInit} from '@angular/core';
 import {Account, SuggestedFees} from '@burstjs/core';
 import {
-  burstAddressPattern, convertAddressToNumericId,
+  convertAddressToNumericId,
   convertNQTStringToNumber,
   convertNumberToNQTString,
   sumNQTStringToNumber
@@ -20,6 +20,7 @@ import {StoreService} from '../../../store/store.service';
 import {takeUntil} from 'rxjs/operators';
 import {UnsubscribeOnDestroy} from '../../../util/UnsubscribeOnDestroy';
 import { ActivatedRoute } from '@angular/router';
+import { burstAddressPattern } from 'app/util/burstAddressPattern';
 
 
 interface QRData {

--- a/web/angular-wallet/src/app/main/send-burst/send-multi-out-form/send-multi-out-form.component.ts
+++ b/web/angular-wallet/src/app/main/send-burst/send-multi-out-form/send-multi-out-form.component.ts
@@ -3,7 +3,6 @@ import {NgForm} from '@angular/forms';
 import {NotifierService} from 'angular-notifier';
 import {
   convertNumberToNQTString,
-  burstAddressPattern,
   convertAddressToNumericId,
   convertNQTStringToNumber
 } from '@burstjs/util';
@@ -15,7 +14,8 @@ import {WarnSendDialogComponent} from '../warn-send-dialog/warn-send-dialog.comp
 import {Recipient} from '../../../layout/components/burst-recipient-input/burst-recipient-input.component';
 import {takeUntil} from 'rxjs/operators';
 import {StoreService} from '../../../store/store.service';
-import {UnsubscribeOnDestroy} from '../../../util/UnsubscribeOnDestroy';
+import {UnsubscribeOnDestroy} from 'app/util/UnsubscribeOnDestroy';
+import {burstAddressPattern} from 'app/util/burstAddressPattern';
 
 const isNotEmpty = (value: string) => value && value.length > 0;
 

--- a/web/angular-wallet/src/app/main/set-account-info/set-account-info.component.ts
+++ b/web/angular-wallet/src/app/main/set-account-info/set-account-info.component.ts
@@ -1,13 +1,13 @@
 import { Component, OnInit, ViewChild, Output, EventEmitter } from '@angular/core';
 import { SuggestedFees, Account } from '@burstjs/core';
 import { NgForm } from '@angular/forms';
-import { burstAddressPattern } from '@burstjs/util';
 import { ActivatedRoute } from '@angular/router';
 import { AccountService } from 'app/setup/account/account.service';
 import { StoreService } from 'app/store/store.service';
 import { NotifierService } from 'angular-notifier';
 import { I18nService } from 'app/layout/components/i18n/i18n.service';
 import { TransactionService } from '../transactions/transaction.service';
+import { burstAddressPattern } from 'app/util/burstAddressPattern';
 
 @Component({
   selector: 'app-set-account-info',
@@ -57,9 +57,8 @@ export class SetAccountInfoComponent implements OnInit {
       });
       this.notifierService.notify('success', this.i18nService.getTranslation('success_set_account_info'));
       this.setAccountInfoForm.resetForm();
-    } catch (e) { 
+    } catch (e) {
       this.notifierService.notify('error', this.i18nService.getTranslation('error_unknown'));
     }
   }
 }
- 

--- a/web/angular-wallet/src/app/main/set-reward-recipient/set-reward-recipient.component.ts
+++ b/web/angular-wallet/src/app/main/set-reward-recipient/set-reward-recipient.component.ts
@@ -1,12 +1,12 @@
 import { Component, OnInit, ViewChild, Output, EventEmitter } from '@angular/core';
 import { SuggestedFees, Account } from '@burstjs/core';
 import { NgForm } from '@angular/forms';
-import { burstAddressPattern } from '@burstjs/util';
 import { ActivatedRoute } from '@angular/router';
 import { AccountService } from 'app/setup/account/account.service';
 import { NotifierService } from 'angular-notifier';
 import { I18nService } from 'app/layout/components/i18n/i18n.service';
 import { Recipient } from 'app/layout/components/burst-recipient-input/burst-recipient-input.component';
+import { burstAddressPattern } from 'app/util/burstAddressPattern';
 
 @Component({
   selector: 'app-set-reward-recipient',
@@ -52,7 +52,7 @@ export class SetRewardRecipientComponent implements OnInit {
       });
       this.notifierService.notify('success', this.i18nService.getTranslation('success_set_reward_recipient'));
       this.setRewardRecipientForm.resetForm();
-    } catch (e) { 
+    } catch (e) {
       this.notifierService.notify('error', e.message || this.i18nService.getTranslation('error_set_reward_recipient'));
     }
   }
@@ -61,4 +61,3 @@ export class SetRewardRecipientComponent implements OnInit {
     this.recipient = recipient;
   }
 }
- 

--- a/web/angular-wallet/src/app/setup/account/create-passive/create-passive.component.ts
+++ b/web/angular-wallet/src/app/setup/account/create-passive/create-passive.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit, Injectable, Input} from '@angular/core';
 import { CreateService } from '../create.service';
 import { NotifierService } from 'angular-notifier';
 import { Router } from '@angular/router';
-import { burstAddressPattern } from '@burstjs/util';
+import { burstAddressPattern } from 'app/util/burstAddressPattern';
 
 @Injectable()
 @Component({
@@ -13,7 +13,7 @@ import { burstAddressPattern } from '@burstjs/util';
 export class CreatePassiveAccountComponent implements OnInit {
 
   address = '';
-  
+
   burstAddressPattern = burstAddressPattern;
 
   constructor(private createService: CreateService,

--- a/web/angular-wallet/src/app/util/burstAddressPattern.ts
+++ b/web/angular-wallet/src/app/util/burstAddressPattern.ts
@@ -1,0 +1,3 @@
+export const burstAddressPattern = {
+  '_': {pattern: new RegExp('\[a-zA-Z0-9\]')}
+};


### PR DESCRIPTION
Removed the `burstAddressPattern` function in @burstjs/util

Motivation:
1. A very UI specific and inaccurate method (meant for formatting?)
2. `isBurstAddress` is more accurate and generic
3. Trouble with rollup bundler (common-js plugin) 