### PR TITLE
Fix/block reward in burst

### DIFF
--- a/web/angular-wallet/src/app/main/blocks/block-details/block-cell-value-mapper.ts
+++ b/web/angular-wallet/src/app/main/blocks/block-details/block-cell-value-mapper.ts
@@ -41,7 +41,7 @@ export class BlockCellValueMapper {
     this.map = {
       nextBlock: this.getTypedValue(this.block.nextBlock, BlockCellValueType.BlockId),
       previousBlock: this.getTypedValue(this.block.previousBlock, BlockCellValueType.BlockId),
-      blockReward: this.getAmount(this.block.blockReward),
+      blockReward: `${this.block.blockReward} BURST`,
       generatorRS: this.getTypedValue(this.block.generatorRS, BlockCellValueType.AccountAddress),
       generator: this.getTypedValue(this.block.generator, BlockCellValueType.AccountId),
       totalFeeNQT: this.getAmount(this.block.totalFeeNQT),

--- a/web/angular-wallet/src/app/main/blocks/block-details/block-cell-value-mapper.ts
+++ b/web/angular-wallet/src/app/main/blocks/block-details/block-cell-value-mapper.ts
@@ -41,7 +41,7 @@ export class BlockCellValueMapper {
     this.map = {
       nextBlock: this.getTypedValue(this.block.nextBlock, BlockCellValueType.BlockId),
       previousBlock: this.getTypedValue(this.block.previousBlock, BlockCellValueType.BlockId),
-      blockReward: `${this.block.blockReward} BURST`,
+      blockReward: this.getAmount(this.block.blockReward, false),
       generatorRS: this.getTypedValue(this.block.generatorRS, BlockCellValueType.AccountAddress),
       generator: this.getTypedValue(this.block.generator, BlockCellValueType.AccountId),
       totalFeeNQT: this.getAmount(this.block.totalFeeNQT),
@@ -56,8 +56,8 @@ export class BlockCellValueMapper {
     return new CellValue(date, CellValueType.Date);
   }
 
-  private getAmount(nqt: string): BlockCellValue {
-    const valueStr = `${convertNQTStringToNumber(nqt)} BURST`;
+  private getAmount(value: string, isPlanck = true): BlockCellValue {
+    const valueStr = `${isPlanck ? convertNQTStringToNumber(value): value} BURST`;
     return new BlockCellValue(valueStr);
   }
 


### PR DESCRIPTION
BlockReward was assumed to be NQT and though shown converted from NQT to BURST, but BRS returns as BURST and not NQT, so conversion is not necessary.

![image](https://user-images.githubusercontent.com/3920663/64909548-197caf00-d6e4-11e9-9093-2b77231e6fc2.png)
