### PR TITLE
fix(mobile): fix double acct creation bug

### DIFF
--- a/mobile/src/modules/auth/components/create/EnterPassphraseStage.tsx
+++ b/mobile/src/modules/auth/components/create/EnterPassphraseStage.tsx
@@ -25,6 +25,8 @@ const getRandomIndex = (length: number): number => {
 };
 
 export class EnterPassphraseStage extends React.PureComponent<Props, State> {
+
+  isDone: boolean = false; // hax: bypass state to avoid double accounts being added
   state: State = {
     offset: 0
   };
@@ -39,7 +41,8 @@ export class EnterPassphraseStage extends React.PureComponent<Props, State> {
         this.setState({
           offset: offset + 1
         });
-      } else {
+      } else if (!this.isDone) {
+        this.isDone = true;
         this.props.onFinish();
       }
     }

--- a/mobile/src/modules/auth/screens/HomeScreen.tsx
+++ b/mobile/src/modules/auth/screens/HomeScreen.tsx
@@ -122,10 +122,10 @@ class Home extends React.PureComponent<TProps, State> {
         <FullHeightView withoutPaddings>
           <AccountsListHeader priceApi={priceApi} accounts={accounts}/>
           <View>
-            <HomeStackedAreaChart
+            {accounts.length && <HomeStackedAreaChart
               priceApi={priceApi}
               accounts={accounts}
-            />
+            /> || null}
             <AccountsList
               accounts={accounts}
               onAccountPress={this.handleAccountPress}

--- a/mobile/src/modules/home/components/HomeStackedAreaChart.tsx
+++ b/mobile/src/modules/home/components/HomeStackedAreaChart.tsx
@@ -182,7 +182,7 @@ export class HomeStackedAreaChart extends React.PureComponent<TProps, State> {
           style={styles.button as StyleMedia}
         >
           <Text style={{ color: Colors.BLUE_LIGHT, textAlign: 'center' }}>
-            {this.state.priceInBTC ? `BTC` : `BURST`} TEST
+            {this.state.priceInBTC ? `BTC` : `BURST`}
           </Text>
         </TouchableOpacity>
       </>


### PR DESCRIPTION
had to bypass `this.state` because apparently it was too slow, causing a pretty to reproduce bug where you would end up with two accounts if you click the last word in the passphrase too fast.