### PR TITLE
fix(mobile): reset PIN in redux store

### DIFF
--- a/mobile/src/modules/auth/store/actions.ts
+++ b/mobile/src/modules/auth/store/actions.ts
@@ -231,6 +231,9 @@ export const setPasscode = createActionFn<string, Promise<void>>(
   async (dispatch, _getState, passcode) => {
     dispatch(actions.setPasscode(passcode));
     await savePasscode(passcode);
+
+    // reset the redux store
+    dispatch(loadPasscode());
   }
 );
 


### PR DESCRIPTION
Discovered an issue where if a PIN is reset, it does not get set in the redux store until after the app is closed/re-opened, which causes any accounts added during that window to be encrypted against the wrong PIN.