### PR TITLE
Fix multi-out jank and add No Transactions Msg to dashboard

### DIFF
--- a/web/angular-wallet/src/app/main/dashboard/dashboard.component.html
+++ b/web/angular-wallet/src/app/main/dashboard/dashboard.component.html
@@ -54,13 +54,10 @@
                                      [account]="account"
                                      [paginationEnabled]="false"
               ></app-transaction-table>
-              <div *ngIf="!dataSource" class="text-center">
+              <div *ngIf="!dataSource || !account.transactions.length">
                 <div>
                   {{ 'no_transactions_yet' | i18n }}
                 </div>
-                <a href="http://faucet.burst-alliance.org:8080" target="_blank">
-                  {{ 'click_to_claim' | i18n }}
-                </a>
               </div>
             </div>
             <a *ngIf="dataSource && dataSource.data.length"

--- a/web/angular-wallet/src/app/main/send-burst/send-multi-out-form/send-multi-out-form.component.html
+++ b/web/angular-wallet/src/app/main/send-burst/send-multi-out-form/send-multi-out-form.component.html
@@ -30,7 +30,7 @@
           <burst-recipient-input [recipientValue]="recipient.addressRaw"
                                  (recipientChange)="onRecipientChange($event, i)"
                                  [withQrCode]="false"></burst-recipient-input>
-          <mat-form-field [class.last]="isLastRecipientItem(i)" *ngIf="!sameAmount">
+          <mat-form-field [class.last]="isLastRecipientItem(i) && i !== 0" *ngIf="!sameAmount">
             <input matInput [(ngModel)]="recipient.amount"
                    name="amount{{i}}"
                    placeholder="{{ 'amount' | i18n }}"

--- a/web/angular-wallet/src/app/main/send-burst/send-multi-out-form/send-multi-out-form.component.html
+++ b/web/angular-wallet/src/app/main/send-burst/send-multi-out-form/send-multi-out-form.component.html
@@ -30,7 +30,7 @@
           <burst-recipient-input [recipientValue]="recipient.addressRaw"
                                  (recipientChange)="onRecipientChange($event, i)"
                                  [withQrCode]="false"></burst-recipient-input>
-          <mat-form-field *ngIf="!sameAmount">
+          <mat-form-field [class.last]="isLastRecipientItem(i)" *ngIf="!sameAmount">
             <input matInput [(ngModel)]="recipient.amount"
                    name="amount{{i}}"
                    placeholder="{{ 'amount' | i18n }}"

--- a/web/angular-wallet/src/app/main/send-burst/send-multi-out-form/send-multi-out-form.component.scss
+++ b/web/angular-wallet/src/app/main/send-burst/send-multi-out-form/send-multi-out-form.component.scss
@@ -36,6 +36,10 @@ form {
         width: 30%
       }
 
+      mat-form-field.last {
+        width: 20%;
+      }
+
       mat-icon {
         cursor: pointer;
       }


### PR DESCRIPTION
Adds a `No recent transactions` message under Recent Transactions.
![image](https://user-images.githubusercontent.com/42594751/70379726-f3326e00-18e4-11ea-9cc7-6b6bd136c509.png)

Fixes the amount field shifting around
![burst-multi-out-jank](https://user-images.githubusercontent.com/42594751/70379802-5670d000-18e6-11ea-8d3b-f681c6fed00f.gif)
