### PR TITLE
fix(AccountDetails): fix qr code url

### DIFF
--- a/web/angular-wallet/src/app/main/accounts/account-details/add-node-url.pipe.ts
+++ b/web/angular-wallet/src/app/main/accounts/account-details/add-node-url.pipe.ts
@@ -1,19 +1,19 @@
-import { Pipe, PipeTransform } from "@angular/core";
-import { ApiService } from "app/api.service";
+import { Pipe, PipeTransform } from '@angular/core';
+import { ApiService } from 'app/api.service';
 
 @Pipe({ name: 'addNodeUrl' })
 export class AddNodeUrlPipe implements PipeTransform {
 
-    nodeUrl: string = '';
-    constructor(private apiService: ApiService) {
-        this.nodeUrl = this.apiService.nodeUrl;
-    }
+  nodeUrl = '';
+  constructor(private apiService: ApiService) {
+    this.nodeUrl = this.apiService.nodeUrl;
+  }
 
-    transform(value: string): string {
-        if (value && value.startsWith('/')) {
-            // remove "/" to avoid double slashes
-            value = value.substr(1, value.length);
-        }
-        return value && `${this.nodeUrl}/${value}`;
+  transform(value: string): string {
+    if (value && value.startsWith('/')) {
+      // remove "/" to avoid double slashes
+      value = value.substr(1, value.length);
     }
+    return value && `${this.nodeUrl}/${value}`;
+  }
 }

--- a/web/angular-wallet/src/app/main/accounts/account-details/add-node-url.pipe.ts
+++ b/web/angular-wallet/src/app/main/accounts/account-details/add-node-url.pipe.ts
@@ -10,9 +10,9 @@ export class AddNodeUrlPipe implements PipeTransform {
     }
 
     transform(value: string): string {
-        if (this.nodeUrl.endsWith('/')) {
-            // remove "/" from end of url to avoid double slashes
-            this.nodeUrl = this.nodeUrl.substr(0, this.nodeUrl.length - 1);
+        if (value && value.startsWith('/')) {
+            // remove "/" to avoid double slashes
+            value = value.substr(1, value.length);
         }
         return value && `${this.nodeUrl}/${value}`;
     }

--- a/web/angular-wallet/src/app/main/accounts/account-details/add-node-url.pipe.ts
+++ b/web/angular-wallet/src/app/main/accounts/account-details/add-node-url.pipe.ts
@@ -10,6 +10,10 @@ export class AddNodeUrlPipe implements PipeTransform {
     }
 
     transform(value: string): string {
+        if (this.nodeUrl.endsWith('/')) {
+            // remove "/" from end of url to avoid double slashes
+            this.nodeUrl = this.nodeUrl.substr(0, this.nodeUrl.length - 1);
+        }
         return value && `${this.nodeUrl}/${value}`;
     }
 }


### PR DESCRIPTION
Fixes this issue on account details:
![image](https://user-images.githubusercontent.com/42594751/71772346-b1eea780-2efe-11ea-97aa-12e2a5b8b8e9.png)
(caused by double slashes in the URL, https://wallet.burst-alliance.org:8125//burst)