### PR TITLE
feat(desktop): add full node support and instructions

### DIFF
--- a/desktop/wallet/README.md
+++ b/desktop/wallet/README.md
@@ -1,10 +1,16 @@
 # The Phoenix Desktop Wallet
 
+## Installation (End Users)
+
+Download the latest release from the [Releases page](https://github.com/burst-apps-team/phoenix/releases). Find your platform and install it. 
+
+## Installation (Developers)
+
 ## Running the latest release (Linux)
 ```console
-$ wget https://github.com/burst-apps-team/phoenix/releases/download/v1.0.0-beta.6/phoenix-1.0.0-beta.6.tar.gz
-$ tar zxvf phoenix-1.0.0-beta.6.tar.gz
-$ cd phoenix-1.0.0-beta.6/
+$ wget https://github.com/burst-apps-team/phoenix/releases/download/desktop-1.0.0-beta.13/linux-phoenix-burst-wallet.1.0.0-beta.13.tar.gz
+$ tar zxvf linux-phoenix-burst-wallet.1.0.0-beta.13.tar.gz
+$ cd linux-phoenix-burst-wallet.1.0.0-beta.13/
 ```
 ```console
 $ sudo chown root:root ./chrome-sandbox

--- a/web/angular-wallet/README.md
+++ b/web/angular-wallet/README.md
@@ -23,3 +23,28 @@ Run `ng test` or `npm test` to execute the unit tests via [Jest](https://jestjs.
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+## Releasing
+
+- Electron: Tag the release (e.g. desktop-1.0.0) and push it up. Travis will build and deploy the electron app. 
+- BRS: Run `npm run build:web`. The output of `dist` can then be dropped into the `html/ui` folder in the BRS jar file, or zipped up for web. Todo: Automate this step.
+
+## Running a full node
+
+Running a full node strengthens the network and adds security. Running a full node allows one to verify transactions without trusting any third parties. To run a full node:
+
+1. Download and configure the [Burst Reference Software (BRS)](https://github.com/burst-apps-team/burstcoin/releases).
+
+2. Install Phoenix from source. 
+
+    `git clone git@github.com:burst-apps-team/phoenix.git`
+
+3. Build Phoenix Desktop with the `web` target.
+
+    `npm run build:web`
+
+4. Copy the files from `dist` into your BRS isntallation's `html/ui` folder.
+
+    `cp dist/* [path to your BRS]/html/ui`
+
+5. Restart BRS. Enjoy!

--- a/web/angular-wallet/src/app/app.component.html
+++ b/web/angular-wallet/src/app/app.component.html
@@ -11,5 +11,7 @@
   <mat-icon *ngIf="isDownloadingUpdate" class="downloading-icon" matTooltip="{{'downloading_update' | i18n}}">autorenew</mat-icon>
 </button>
 
-
-<!--<div *ngIf="isScanning" class="downloading">{{ 'downloading_blockchain' | i18n }}</div>-->
+<div *ngIf="downloadingBlockchain" class="downloading">
+  {{ 'downloading_blockchain' | i18n }} ({{ numberOfBlocks }} / {{lastBlockchainFeederHeight}})
+  <mat-progress-bar mode="determinate" [value]="percentDownloaded"></mat-progress-bar>
+</div>

--- a/web/angular-wallet/src/app/app.module.ts
+++ b/web/angular-wallet/src/app/app.module.ts
@@ -32,6 +32,7 @@ import {SettingsResolver} from './store/settings.resolver';
 import {registerLocales} from '../app/layout/components/i18n/locales';
 import {NgxElectronModule} from 'ngx-electron';
 import {NewVersionDialogComponent} from './components/new-version-dialog/new-version-dialog.component';
+import { MatProgressBarModule } from '@angular/material';
 
 registerLocales();
 
@@ -76,7 +77,8 @@ const appRoutes: Routes = [
     MatCardModule,
     MatTooltipModule,
     MatFormFieldModule,
-    MatSelectModule
+    MatSelectModule,
+    MatProgressBarModule
   ],
   providers: [
     StoreService,

--- a/web/angular-wallet/src/app/layout/components/footer/footer.component.html
+++ b/web/angular-wallet/src/app/layout/components/footer/footer.component.html
@@ -2,19 +2,6 @@
 
     <div fxLayout="row" fxLayoutAlign="center center" fxLayoutAlign.gt-xs="space-between center" fxFlex>
 
-        <a href="https://1.envato.market/c/1257954/275988/4415?u=https%3A%2F%2Fthemeforest.net%2Fitem%2Ffuse-angularjs-material-design-admin-template%2F12931855"
-           target="_blank" mat-button class="pink" fxFlex="0 0 auto" fxLayout="row"
-           fxLayoutAlign="start center">
-            <mat-icon class="s-16 mr-sm-4">shopping_cart</mat-icon>
-            <span>Purchase FUSE (Angular 7+)</span>
-        </a>
-
-        <div fxLayout="row" fxLayoutAlign="start center" fxHide fxShow.gt-xs>
-            <a mat-button routerLink="/documentation/getting-started/introduction">Documentation</a>
-            <span>&bull;</span>
-            <a mat-button routerLink="/documentation/changelog">Changelog</a>
-        </div>
-
     </div>
 
 </mat-toolbar>

--- a/web/angular-wallet/src/app/layout/components/footer/footer.component.ts
+++ b/web/angular-wallet/src/app/layout/components/footer/footer.component.ts
@@ -1,16 +1,15 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
+import { NetworkService } from 'app/network/network.service';
+import { FuseConfigService } from '@fuse/services/config.service';
 
 @Component({
     selector   : 'footer',
     templateUrl: './footer.component.html',
     styleUrls  : ['./footer.component.scss']
 })
-export class FooterComponent
-{
-    /**
-     * Constructor
-     */
-    constructor()
-    {
+export class FooterComponent {
+
+    constructor() {
     }
+
 }


### PR DESCRIPTION
Add support and instructions for full node support.

Basically requires the user to download/build the web wallet with a `web` target, and then drop that into their `html/ui` folder in BRS. That's it!