### PR TITLE
chore: changed big.js by bignumber.js

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -7153,7 +7153,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -9067,7 +9068,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -17041,7 +17043,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/lib/packages/util/package-lock.json
+++ b/lib/packages/util/package-lock.json
@@ -881,10 +881,14 @@
 				"@types/yargs": "^13.0.0"
 			}
 		},
-		"@types/big.js": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@types/big.js/-/big.js-4.0.5.tgz",
-			"integrity": "sha512-D9KFrAt05FDSqLo7PU9TDHfDgkarlwdkuwFsg7Zm4xl62tTNaz+zN+Tkcdx2wGLBbSMf8BnoMhOVeUGUaJfLKg=="
+		"@types/bignumber.js": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
+			"integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
+			"dev": true,
+			"requires": {
+				"bignumber.js": "*"
+			}
 		},
 		"@types/estree": {
 			"version": "0.0.39",
@@ -1029,6 +1033,11 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+		},
+		"bignumber.js": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
 		},
 		"bili": {
 			"version": "4.8.1",

--- a/lib/packages/util/package.json
+++ b/lib/packages/util/package.json
@@ -37,6 +37,7 @@
     ]
   },
   "devDependencies": {
+    "@types/bignumber.js": "^5.0.0",
     "@types/jest": "^24.0.23",
     "bili": "^4.8.1",
     "rollup-plugin-typescript2": "^0.24.2"
@@ -57,8 +58,7 @@
   },
   "gitHead": "9b5a4e07616d783e85bcae6c21b72f50db783f48",
   "dependencies": {
-    "@types/big.js": "^4.0.5",
-    "big.js": "^5.2.2",
+    "bignumber.js": "^9.0.0",
     "js-base64": "^2.5.1"
   }
 }

--- a/lib/packages/util/src/__tests__/burstValue.spec.ts
+++ b/lib/packages/util/src/__tests__/burstValue.spec.ts
@@ -70,7 +70,7 @@ describe('BurstValue', () => {
             const burstValue = BurstValue.fromBurst('1');
             expect(burstValue.getBurst()).toEqual('1');
             const raw = burstValue.getRaw();
-            raw.add(1);
+            raw.plus(1);
             expect(burstValue.getBurst()).toEqual('1');
         });
     });
@@ -216,7 +216,7 @@ describe('BurstValue', () => {
         it('should throw error div-by-zero', () => {
             const burstValue1 = BurstValue.fromBurst('10');
             expect(() => {
-                burstValue1.divide(0).getBurst()
+                burstValue1.divide(0).getBurst();
             }).toThrow();
         });
     });

--- a/lib/packages/util/src/burstValue.ts
+++ b/lib/packages/util/src/burstValue.ts
@@ -1,15 +1,22 @@
 /**
  * Original work Copyright (c) 2020 Burst Apps Team
  */
-
-import Big from 'big.js';
+import BigNumber from 'bignumber.js';
 import {BurstPlanckSymbol, BurstSymbol} from './constants';
 
-Big.NE = -9;
+BigNumber.config({
+    EXPONENTIAL_AT: [-9, 20]
+});
 
 export enum BurstValueFormat {
     PLANCK,
     BURST,
+}
+
+function assureValidValue(b: string) {
+    if (!(b && /^-?\d*(\.\d+)?$/.test(b))) {
+        throw new Error(`Invalid value: ${b}`);
+    }
 }
 
 /**
@@ -22,10 +29,11 @@ export enum BurstValueFormat {
  */
 export class BurstValue {
 
-    private _planck: Big;
+    private _planck: BigNumber;
 
     private constructor(planck: string) {
-        this._planck = Big(planck);
+        assureValidValue(planck);
+        this._planck = new BigNumber(planck);
     }
 
     /**
@@ -50,8 +58,8 @@ export class BurstValue {
      * Leaky value getter
      * @return the underlying value in its big number representation (immutable)
      */
-    getRaw(): Big {
-        return Big(this._planck);
+    getRaw(): BigNumber {
+        return this._planck;
     }
 
     /**
@@ -66,7 +74,8 @@ export class BurstValue {
      * @param p The planck value
      */
     setPlanck(p: string): void {
-        this._planck = Big(p);
+        assureValidValue(p);
+        this._planck = new BigNumber(p);
     }
 
     /**
@@ -74,7 +83,7 @@ export class BurstValue {
      * @return value in BURST
      */
     getBurst(): string {
-        return Big(this._planck).div(1E8).toString();
+        return this._planck.dividedBy(1E8).toString();
     }
 
     /**
@@ -82,7 +91,8 @@ export class BurstValue {
      * @param b value in BURST
      */
     setBurst(b: string) {
-        this._planck = Big(b).mul(1E8);
+        assureValidValue(b);
+        this._planck = new BigNumber(b).multipliedBy(1E8);
     }
 
     /**
@@ -156,7 +166,7 @@ export class BurstValue {
      * @return the mutated BurstValue object
      */
     public multiply(value: number): BurstValue {
-        this._planck = this._planck.mul(value);
+        this._planck = this._planck.multipliedBy(value);
         return this;
     }
 
@@ -166,6 +176,7 @@ export class BurstValue {
      * @return the mutated BurstValue object
      */
     public divide(value: number): BurstValue {
+        if (value === 0) { throw new Error('Division by zero'); }
         this._planck = this._planck.div(value);
         return this;
     }


### PR DESCRIPTION
We had two different Big Number libs in our packages. Although, big.js is smaller it lacks some functionality we need, i.e. hex/dec conversion. Now, we use only bignumber.js which I expect to be advantageous for bundling also (deduping/tree-shaking)