### PR TITLE
fix(assets): updated assetBalances on refreshAccount

### DIFF
--- a/web/angular-wallet/src/app/store/store.service.ts
+++ b/web/angular-wallet/src/app/store/store.service.ts
@@ -74,6 +74,7 @@ export class StoreService {
           } else {
             accounts.chain().find({account: account.account}).update(w => {
               w.balanceNQT = account.balanceNQT;
+              w.assetBalances = account.assetBalances;
               w.type = account.type;
               w.selected = account.selected;
               w.name = account.name;


### PR DESCRIPTION
Closes #1320 

Note: This looks like it might be getting deprecated in 3.0, may need to revise this a bit soon.