### PR TITLE
feat: dramatically reduces transaction payload

### DIFF
--- a/web/angular-wallet/src/app/main/messages/messages.service.ts
+++ b/web/angular-wallet/src/app/main/messages/messages.service.ts
@@ -178,13 +178,14 @@ export class MessagesService implements Resolve<any> {
     const maxNumberMessages = 100;
     const accountId = this.accountService.currentAccount.getValue().account;
 
-    const getConfirmedMessages = this.accountService.getAccountTransactions(
+    const getConfirmedMessages = this.accountService.getAccountTransactions({
       accountId,
-      0, maxNumberMessages,
-      0,
-      TransactionType.Arbitrary,
-      TransactionArbitrarySubtype.Message);
-
+      firstIndex: 0,
+      lastIndex: maxNumberMessages,
+      type: TransactionType.Arbitrary,
+      subtype: TransactionArbitrarySubtype.Message,
+      includeIndirect: false,
+    });
     const getUnconfirmedMessages = this.accountService.getUnconfirmedTransactions(accountId);
 
     const messages = await Promise.all([getConfirmedMessages, getUnconfirmedMessages]);


### PR DESCRIPTION
This PR is using an incremental tx request approach, thus solving #1509 

Instead of fetching all (500) transactions it just pulls all since the last stored one. This reduces the entire outgoing traffic of a node by two dimensions

__Before__
![image](https://user-images.githubusercontent.com/3920663/126206111-a4305c71-0e6a-4989-a5e9-c67b49d1984f.png)


__After__
![image](https://user-images.githubusercontent.com/3920663/126206231-8353e924-31e8-4cee-8d0e-503d02760c96.png)


